### PR TITLE
Allow Tapioca 0.19.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     boba (0.1.11)
-      tapioca (<= 0.19.1)
+      tapioca (<= 0.19.2)
 
 GEM
   remote: https://rubygems.org/
@@ -260,7 +260,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
-    rbi (0.3.12)
+    rbi (0.4.3)
       prism (~> 1.0)
       rbs (>= 4.0.1)
     rbs (4.0.2)
@@ -319,10 +319,10 @@ GEM
     sorbet-static-and-runtime (0.6.13228)
       sorbet (= 0.6.13228)
       sorbet-runtime (= 0.6.13228)
-    spoom (1.7.15)
+    spoom (1.8.7)
       erubi (>= 1.10.0)
       prism (>= 0.28.0)
-      rbi (>= 0.3.3)
+      rbi (>= 0.4.2)
       rbs (>= 4.0.0.dev.5)
       rexml (>= 3.2.6)
       sorbet-static-and-runtime (>= 0.5.10187)
@@ -335,7 +335,7 @@ GEM
     sqlite3 (2.9.4-x86_64-linux-musl)
     state_machines (0.101.0)
     stringio (3.2.0)
-    tapioca (0.19.1)
+    tapioca (0.19.2)
       benchmark
       bundler (>= 2.2.25)
       netrc (>= 0.11.0)
@@ -344,7 +344,7 @@ GEM
       require-hooks (>= 0.2.2)
       rubydex (>= 0.1.0.beta10)
       sorbet-static-and-runtime (>= 0.6.12698)
-      spoom (>= 1.7.9)
+      spoom (>= 1.7.16)
       thor (>= 1.2.0)
       tsort
     terrapin (0.6.0)
@@ -493,7 +493,7 @@ CHECKSUMS
   railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  rbi (0.3.12) sha256=406ea58265942e7f2316744a11de742fdef8b2325bb6066c71c9765f53298eb2
+  rbi (0.4.3) sha256=cc090ae62c3246412b992954f54077d6046c9b04f1537a4d24bfae8714503eac
   rbs (4.0.2) sha256=af75671e66cd03434cc546622741ebf83f6197ec4328375805306330bf78ef25
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
@@ -520,7 +520,7 @@ CHECKSUMS
   sorbet-static (0.6.13228-universal-darwin) sha256=d5e58c7e4f9f7f009af508d621054b04a5459defda2612bc2840019f903577c1
   sorbet-static (0.6.13228-x86_64-linux) sha256=022b7089753b890f072e5dc905b92a42a709e39ceb0e519920fee6d9047a6fe5
   sorbet-static-and-runtime (0.6.13228) sha256=b7420ff130082b70af81666978db2f9a9342a60a14f2e19f5b63d03c9a832f77
-  spoom (1.7.15) sha256=39698a3bf7841841ae83c6145d5e008290ddb9433e84d9025e017b915bd36a83
+  spoom (1.8.7) sha256=81960502cdf23aa991f015988aa5dd43325e23ae4318b8e00d541299cbdb70f6
   sqlite3 (2.9.4-aarch64-linux-gnu) sha256=ecabed721e6eaad54601d2685f09029d90025efc8d931040dc89cb3f8a2080ec
   sqlite3 (2.9.4-aarch64-linux-musl) sha256=ffb4255947fb54c8c3eeca97460c9702b40de91ce390455ef7367ca6a3929a31
   sqlite3 (2.9.4-arm64-darwin) sha256=1d5aad413a815d236e96d43f05a1acc600b6cd086800770342a3f9c2877499ff
@@ -529,7 +529,7 @@ CHECKSUMS
   sqlite3 (2.9.4-x86_64-linux-musl) sha256=3fc5e865b4be9a85d998203ef8d0c0fdcb92f20acf34a254346ff8a19088efec
   state_machines (0.101.0) sha256=cbcec89699a0388493226a4b18d790bd5d49c38ba782d2099342a3dd78bcbca3
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
-  tapioca (0.19.1) sha256=5de94d458950897ffe3d4e86a21eec48bb6a8775af85f80b1486b7ae7ba51823
+  tapioca (0.19.2) sha256=938731b07811aee8d23871b1aee8861d464fbaf2cfffbf79a62b0c869a5120ec
   terrapin (0.6.0) sha256=c9fea9f13a40dc7c75212d1b9d4ee7e4542ffe7811bf700a38ba30900b70285c
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb

--- a/boba.gemspec
+++ b/boba.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.0.0"
 
   spec.add_development_dependency("sorbet", ">= 0.6.12698")
-  spec.add_dependency("tapioca", "<= 0.19.1")
+  spec.add_dependency("tapioca", "<= 0.19.2")
 end

--- a/sorbet/rbi/gems/rbi@0.4.3.rbi
+++ b/sorbet/rbi/gems/rbi@0.4.3.rbi
@@ -14,21 +14,21 @@
 # pkg:gem/rbi#lib/rbi.rb:7
 module RBI; end
 
-# pkg:gem/rbi#lib/rbi/model.rb:862
+# pkg:gem/rbi#lib/rbi/model.rb:1011
 class RBI::Arg < ::RBI::Node
-  # pkg:gem/rbi#lib/rbi/model.rb:867
+  # pkg:gem/rbi#lib/rbi/model.rb:1016
   sig { params(value: ::String, loc: T.nilable(::RBI::Loc)).void }
   def initialize(value, loc: T.unsafe(nil)); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:873
+  # pkg:gem/rbi#lib/rbi/model.rb:1022
   sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
   def ==(other); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:878
+  # pkg:gem/rbi#lib/rbi/model.rb:1027
   sig { returns(::String) }
   def to_s; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:864
+  # pkg:gem/rbi#lib/rbi/model.rb:1013
   sig { returns(::String) }
   def value; end
 end
@@ -165,7 +165,7 @@ class RBI::AttrAccessor < ::RBI::Attr
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rewriters/attr_to_methods.rb:130
+  # pkg:gem/rbi#lib/rbi/rewriters/attr_to_methods.rb:131
   sig { override.returns(T::Array[::RBI::Method]) }
   def convert_to_methods; end
 
@@ -206,7 +206,7 @@ class RBI::AttrReader < ::RBI::Attr
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rewriters/attr_to_methods.rb:145
+  # pkg:gem/rbi#lib/rbi/rewriters/attr_to_methods.rb:146
   sig { override.returns(T::Array[::RBI::Method]) }
   def convert_to_methods; end
 
@@ -247,7 +247,7 @@ class RBI::AttrWriter < ::RBI::Attr
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rewriters/attr_to_methods.rb:155
+  # pkg:gem/rbi#lib/rbi/rewriters/attr_to_methods.rb:156
   sig { override.returns(T::Array[::RBI::Method]) }
   def convert_to_methods; end
 
@@ -273,12 +273,12 @@ class RBI::BlankLine < ::RBI::Comment
   def initialize(loc: T.unsafe(nil)); end
 end
 
-# pkg:gem/rbi#lib/rbi/model.rb:710
+# pkg:gem/rbi#lib/rbi/model.rb:843
 class RBI::BlockParam < ::RBI::Param
-  # pkg:gem/rbi#lib/rbi/model.rb:712
+  # pkg:gem/rbi#lib/rbi/model.rb:849
   sig do
     params(
-      name: ::String,
+      name: T.nilable(::String),
       loc: T.nilable(::RBI::Loc),
       comments: T.nilable(T::Array[::RBI::Comment]),
       block: T.nilable(T.proc.params(node: ::RBI::BlockParam).void)
@@ -286,9 +286,25 @@ class RBI::BlockParam < ::RBI::Param
   end
   def initialize(name, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 
+  # pkg:gem/rbi#lib/rbi/model.rb:868
+  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
+  def ==(other); end
+
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:719
+  # pkg:gem/rbi#lib/rbi/model.rb:863
+  sig { override.returns(T::Boolean) }
+  def anonymous?; end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:846
+  sig { override.returns(T.nilable(::String)) }
+  def name; end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:857
   sig { override.returns(::String) }
   def to_s; end
 end
@@ -364,24 +380,24 @@ end
 # end
 # ~~~
 #
-# pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:591
+# pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:634
 class RBI::ConflictTree < ::RBI::Tree
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:599
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:642
   sig { params(left_name: ::String, right_name: ::String).void }
   def initialize(left_name: T.unsafe(nil), right_name: T.unsafe(nil)); end
 
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:593
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:636
   sig { returns(::RBI::Tree) }
   def left; end
 
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:596
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:639
   sig { returns(::String) }
   def left_name; end
 
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:593
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:636
   def right; end
 
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:596
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:639
   def right_name; end
 end
 
@@ -439,11 +455,11 @@ class RBI::DuplicateNodeError < ::RBI::Error; end
 # pkg:gem/rbi#lib/rbi.rb:8
 class RBI::Error < ::StandardError; end
 
-# pkg:gem/rbi#lib/rbi/model.rb:752
+# pkg:gem/rbi#lib/rbi/model.rb:901
 class RBI::Extend < ::RBI::Mixin
   include ::RBI::Indexable
 
-  # pkg:gem/rbi#lib/rbi/model.rb:754
+  # pkg:gem/rbi#lib/rbi/model.rb:903
   sig do
     params(
       name: ::String,
@@ -457,7 +473,7 @@ class RBI::Extend < ::RBI::Mixin
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:524
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:567
   sig { override.params(other: ::RBI::Node).returns(T::Boolean) }
   def compatible_with?(other); end
 
@@ -469,7 +485,7 @@ class RBI::Extend < ::RBI::Mixin
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:761
+  # pkg:gem/rbi#lib/rbi/model.rb:910
   sig { override.returns(::String) }
   def to_s; end
 end
@@ -506,7 +522,7 @@ class RBI::File
   sig { returns(T::Boolean) }
   def empty?; end
 
-  # pkg:gem/rbi#lib/rbi/printer.rb:877
+  # pkg:gem/rbi#lib/rbi/printer.rb:866
   sig do
     params(
       out: T.any(::IO, ::StringIO),
@@ -517,11 +533,11 @@ class RBI::File
   end
   def print(out: T.unsafe(nil), indent: T.unsafe(nil), print_locs: T.unsafe(nil), max_line_length: T.unsafe(nil)); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1236
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1218
   sig { params(out: T.any(::IO, ::StringIO), indent: ::Integer, print_locs: T::Boolean).void }
   def rbs_print(out: T.unsafe(nil), indent: T.unsafe(nil), print_locs: T.unsafe(nil)); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1242
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1224
   sig { params(indent: ::Integer, print_locs: T::Boolean).returns(::String) }
   def rbs_string(indent: T.unsafe(nil), print_locs: T.unsafe(nil)); end
 
@@ -539,7 +555,7 @@ class RBI::File
   # pkg:gem/rbi#lib/rbi/model.rb:148
   def strictness=(_arg0); end
 
-  # pkg:gem/rbi#lib/rbi/printer.rb:883
+  # pkg:gem/rbi#lib/rbi/printer.rb:872
   sig { params(indent: ::Integer, print_locs: T::Boolean, max_line_length: T.nilable(::Integer)).returns(::String) }
   def string(indent: T.unsafe(nil), print_locs: T.unsafe(nil), max_line_length: T.unsafe(nil)); end
 end
@@ -645,11 +661,11 @@ class RBI::GroupNodesError < ::RBI::Error; end
 
 # Sorbet's misc.
 #
-# pkg:gem/rbi#lib/rbi/model.rb:1187
+# pkg:gem/rbi#lib/rbi/model.rb:1349
 class RBI::Helper < ::RBI::NodeWithComments
   include ::RBI::Indexable
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1192
+  # pkg:gem/rbi#lib/rbi/model.rb:1354
   sig do
     params(
       name: ::String,
@@ -662,7 +678,7 @@ class RBI::Helper < ::RBI::NodeWithComments
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:540
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:583
   sig { override.params(other: ::RBI::Node).returns(T::Boolean) }
   def compatible_with?(other); end
 
@@ -672,22 +688,22 @@ class RBI::Helper < ::RBI::NodeWithComments
   sig { override.returns(T::Array[::String]) }
   def index_ids; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1189
+  # pkg:gem/rbi#lib/rbi/model.rb:1351
   sig { returns(::String) }
   def name; end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:1200
+  # pkg:gem/rbi#lib/rbi/model.rb:1362
   sig { override.returns(::String) }
   def to_s; end
 end
 
-# pkg:gem/rbi#lib/rbi/model.rb:738
+# pkg:gem/rbi#lib/rbi/model.rb:887
 class RBI::Include < ::RBI::Mixin
   include ::RBI::Indexable
 
-  # pkg:gem/rbi#lib/rbi/model.rb:740
+  # pkg:gem/rbi#lib/rbi/model.rb:889
   sig do
     params(
       name: ::String,
@@ -701,7 +717,7 @@ class RBI::Include < ::RBI::Mixin
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:516
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:559
   sig { override.params(other: ::RBI::Node).returns(T::Boolean) }
   def compatible_with?(other); end
 
@@ -713,7 +729,7 @@ class RBI::Include < ::RBI::Mixin
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:747
+  # pkg:gem/rbi#lib/rbi/model.rb:896
   sig { override.returns(::String) }
   def to_s; end
 end
@@ -773,28 +789,28 @@ module RBI::Indexable
   def index_ids; end
 end
 
-# pkg:gem/rbi#lib/rbi/model.rb:883
+# pkg:gem/rbi#lib/rbi/model.rb:1032
 class RBI::KwArg < ::RBI::Arg
-  # pkg:gem/rbi#lib/rbi/model.rb:888
+  # pkg:gem/rbi#lib/rbi/model.rb:1037
   sig { params(keyword: ::String, value: ::String, loc: T.nilable(::RBI::Loc)).void }
   def initialize(keyword, value, loc: T.unsafe(nil)); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:894
+  # pkg:gem/rbi#lib/rbi/model.rb:1043
   sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
   def ==(other); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:885
+  # pkg:gem/rbi#lib/rbi/model.rb:1034
   sig { returns(::String) }
   def keyword; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:899
+  # pkg:gem/rbi#lib/rbi/model.rb:1048
   sig { returns(::String) }
   def to_s; end
 end
 
-# pkg:gem/rbi#lib/rbi/model.rb:678
+# pkg:gem/rbi#lib/rbi/model.rb:754
 class RBI::KwOptParam < ::RBI::Param
-  # pkg:gem/rbi#lib/rbi/model.rb:683
+  # pkg:gem/rbi#lib/rbi/model.rb:763
   sig do
     params(
       name: ::String,
@@ -806,20 +822,36 @@ class RBI::KwOptParam < ::RBI::Param
   end
   def initialize(name, value, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 
+  # pkg:gem/rbi#lib/rbi/model.rb:783
+  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
+  def ==(other); end
+
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:691
+  # pkg:gem/rbi#lib/rbi/model.rb:778
+  sig { override.returns(T::Boolean) }
+  def anonymous?; end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:757
+  sig { override.returns(::String) }
+  def name; end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:772
   sig { override.returns(::String) }
   def to_s; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:680
+  # pkg:gem/rbi#lib/rbi/model.rb:760
   sig { returns(::String) }
   def value; end
 end
 
-# pkg:gem/rbi#lib/rbi/model.rb:664
+# pkg:gem/rbi#lib/rbi/model.rb:724
 class RBI::KwParam < ::RBI::Param
-  # pkg:gem/rbi#lib/rbi/model.rb:666
+  # pkg:gem/rbi#lib/rbi/model.rb:730
   sig do
     params(
       name: ::String,
@@ -830,19 +862,35 @@ class RBI::KwParam < ::RBI::Param
   end
   def initialize(name, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 
+  # pkg:gem/rbi#lib/rbi/model.rb:749
+  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
+  def ==(other); end
+
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:673
+  # pkg:gem/rbi#lib/rbi/model.rb:744
+  sig { override.returns(T::Boolean) }
+  def anonymous?; end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:727
+  sig { override.returns(::String) }
+  def name; end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:738
   sig { override.returns(::String) }
   def to_s; end
 end
 
-# pkg:gem/rbi#lib/rbi/model.rb:696
+# pkg:gem/rbi#lib/rbi/model.rb:788
 class RBI::KwRestParam < ::RBI::Param
-  # pkg:gem/rbi#lib/rbi/model.rb:698
+  # pkg:gem/rbi#lib/rbi/model.rb:794
   sig do
     params(
-      name: ::String,
+      name: T.nilable(::String),
       loc: T.nilable(::RBI::Loc),
       comments: T.nilable(T::Array[::RBI::Comment]),
       block: T.nilable(T.proc.params(node: ::RBI::KwRestParam).void)
@@ -850,9 +898,25 @@ class RBI::KwRestParam < ::RBI::Param
   end
   def initialize(name, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 
+  # pkg:gem/rbi#lib/rbi/model.rb:813
+  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
+  def ==(other); end
+
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:705
+  # pkg:gem/rbi#lib/rbi/model.rb:808
+  sig { override.returns(T::Boolean) }
+  def anonymous?; end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:791
+  sig { override.returns(T.nilable(::String)) }
+  def name; end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:802
   sig { override.returns(::String) }
   def to_s; end
 end
@@ -892,11 +956,15 @@ class RBI::Loc
   sig { params(other: ::RBI::Loc).returns(::RBI::Loc) }
   def join(other); end
 
-  # pkg:gem/rbi#lib/rbi/loc.rb:61
+  # pkg:gem/rbi#lib/rbi/loc.rb:52
+  sig { returns(T::Boolean) }
+  def multiline?; end
+
+  # pkg:gem/rbi#lib/rbi/loc.rb:68
   sig { returns(T.nilable(::String)) }
   def source; end
 
-  # pkg:gem/rbi#lib/rbi/loc.rb:52
+  # pkg:gem/rbi#lib/rbi/loc.rb:59
   sig { returns(::String) }
   def to_s; end
 
@@ -952,7 +1020,7 @@ class RBI::Method < ::RBI::NodeWithComments
   sig { params(param: ::RBI::Param).void }
   def <<(param); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:546
+  # pkg:gem/rbi#lib/rbi/model.rb:551
   sig { params(name: ::String).void }
   def add_block_param(name); end
 
@@ -968,6 +1036,10 @@ class RBI::Method < ::RBI::NodeWithComments
   sig { params(name: ::String).void }
   def add_kw_rest_param(name); end
 
+  # pkg:gem/rbi#lib/rbi/model.rb:546
+  sig { void }
+  def add_no_kw_param; end
+
   # pkg:gem/rbi#lib/rbi/model.rb:521
   sig { params(name: ::String, default_value: ::String).void }
   def add_opt_param(name, default_value); end
@@ -980,11 +1052,12 @@ class RBI::Method < ::RBI::NodeWithComments
   sig { params(name: ::String).void }
   def add_rest_param(name); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:559
+  # pkg:gem/rbi#lib/rbi/model.rb:565
   sig do
     params(
       params: T.nilable(T::Array[::RBI::SigParam]),
       return_type: T.any(::RBI::Type, ::String),
+      bind_type: T.nilable(T.any(::RBI::Type, ::String)),
       is_abstract: T::Boolean,
       is_override: T::Boolean,
       is_overridable: T::Boolean,
@@ -994,7 +1067,7 @@ class RBI::Method < ::RBI::NodeWithComments
       block: T.nilable(T.proc.params(node: ::RBI::Sig).void)
     ).void
   end
-  def add_sig(params: T.unsafe(nil), return_type: T.unsafe(nil), is_abstract: T.unsafe(nil), is_override: T.unsafe(nil), is_overridable: T.unsafe(nil), is_final: T.unsafe(nil), type_params: T.unsafe(nil), checked: T.unsafe(nil), &block); end
+  def add_sig(params: T.unsafe(nil), return_type: T.unsafe(nil), bind_type: T.unsafe(nil), is_abstract: T.unsafe(nil), is_override: T.unsafe(nil), is_overridable: T.unsafe(nil), is_final: T.unsafe(nil), type_params: T.unsafe(nil), checked: T.unsafe(nil), &block); end
 
   # @override
   #
@@ -1002,7 +1075,7 @@ class RBI::Method < ::RBI::NodeWithComments
   sig { override.params(other: ::RBI::Node).returns(T::Boolean) }
   def compatible_with?(other); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:585
+  # pkg:gem/rbi#lib/rbi/model.rb:593
   sig { returns(::String) }
   def fully_qualified_name; end
 
@@ -1021,7 +1094,7 @@ class RBI::Method < ::RBI::NodeWithComments
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:476
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:482
   sig { override.params(other: ::RBI::Node).void }
   def merge_with(other); end
 
@@ -1047,7 +1120,7 @@ class RBI::Method < ::RBI::NodeWithComments
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:595
+  # pkg:gem/rbi#lib/rbi/model.rb:603
   sig { override.returns(::String) }
   def to_s; end
 
@@ -1060,16 +1133,24 @@ class RBI::Method < ::RBI::NodeWithComments
 
   private
 
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:498
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:504
   sig { params(other: ::RBI::Method).returns(T::Boolean) }
-  def at_most_one_side_anonymous?(other); end
+  def compatible_params?(other); end
+
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:513
+  sig { params(preferred: T::Array[::RBI::Param], fallback: T::Array[::RBI::Param]).returns(T::Array[::RBI::Param]) }
+  def merge_params(preferred, fallback); end
+
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:524
+  sig { params(sigs: T::Array[::RBI::Sig], params: T::Array[::RBI::Param]).void }
+  def rename_sigs_params(sigs, params); end
 end
 
-# pkg:gem/rbi#lib/rbi/model.rb:1231
+# pkg:gem/rbi#lib/rbi/model.rb:1393
 class RBI::MixesInClassMethods < ::RBI::Mixin
   include ::RBI::Indexable
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1238
+  # pkg:gem/rbi#lib/rbi/model.rb:1400
   sig do
     params(
       name: ::String,
@@ -1083,7 +1164,7 @@ class RBI::MixesInClassMethods < ::RBI::Mixin
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:532
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:575
   sig { override.params(other: ::RBI::Node).returns(T::Boolean) }
   def compatible_with?(other); end
 
@@ -1095,18 +1176,18 @@ class RBI::MixesInClassMethods < ::RBI::Mixin
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:1245
+  # pkg:gem/rbi#lib/rbi/model.rb:1407
   sig { override.returns(::String) }
   def to_s; end
 end
 
 # @abstract
 #
-# pkg:gem/rbi#lib/rbi/model.rb:727
+# pkg:gem/rbi#lib/rbi/model.rb:876
 class RBI::Mixin < ::RBI::NodeWithComments
   abstract!
 
-  # pkg:gem/rbi#lib/rbi/model.rb:732
+  # pkg:gem/rbi#lib/rbi/model.rb:881
   sig do
     params(
       name: ::String,
@@ -1119,11 +1200,11 @@ class RBI::Mixin < ::RBI::NodeWithComments
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:508
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:551
   sig { override.params(other: ::RBI::Node).returns(T::Boolean) }
   def compatible_with?(other); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:729
+  # pkg:gem/rbi#lib/rbi/model.rb:878
   sig { returns(T::Array[::String]) }
   def names; end
 end
@@ -1158,6 +1239,35 @@ class RBI::Module < ::RBI::Scope
   def name; end
 end
 
+# pkg:gem/rbi#lib/rbi/model.rb:818
+class RBI::NoKwParam < ::RBI::Param
+  # pkg:gem/rbi#lib/rbi/model.rb:820
+  sig do
+    params(
+      loc: T.nilable(::RBI::Loc),
+      comments: T.nilable(T::Array[::RBI::Comment]),
+      block: T.nilable(T.proc.params(node: ::RBI::NoKwParam).void)
+    ).void
+  end
+  def initialize(loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
+
+  # pkg:gem/rbi#lib/rbi/model.rb:838
+  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
+  def ==(other); end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:833
+  sig { override.returns(T::Boolean) }
+  def anonymous?; end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:827
+  sig { override.returns(::String) }
+  def to_s; end
+end
+
 # @abstract
 #
 # pkg:gem/rbi#lib/rbi/model.rb:8
@@ -1171,6 +1281,7 @@ class RBI::Node
   # Can `self` and `_other` be merged into a single definition?
   #
   # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:302
+  sig { params(_other: ::RBI::Node).returns(T::Boolean) }
   def compatible_with?(_other); end
 
   # pkg:gem/rbi#lib/rbi/model.rb:22
@@ -1205,7 +1316,7 @@ class RBI::Node
   # pkg:gem/rbi#lib/rbi/model.rb:10
   def parent_tree=(_arg0); end
 
-  # pkg:gem/rbi#lib/rbi/printer.rb:895
+  # pkg:gem/rbi#lib/rbi/printer.rb:884
   sig do
     params(
       out: T.any(::IO, ::StringIO),
@@ -1216,7 +1327,7 @@ class RBI::Node
   end
   def print(out: T.unsafe(nil), indent: T.unsafe(nil), print_locs: T.unsafe(nil), max_line_length: T.unsafe(nil)); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1251
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1233
   sig do
     params(
       out: T.any(::IO, ::StringIO),
@@ -1227,7 +1338,7 @@ class RBI::Node
   end
   def rbs_print(out: T.unsafe(nil), indent: T.unsafe(nil), print_locs: T.unsafe(nil), positional_names: T.unsafe(nil)); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1257
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1239
   sig { params(indent: ::Integer, print_locs: T::Boolean, positional_names: T::Boolean).returns(::String) }
   def rbs_string(indent: T.unsafe(nil), print_locs: T.unsafe(nil), positional_names: T.unsafe(nil)); end
 
@@ -1239,7 +1350,7 @@ class RBI::Node
   sig { params(version: ::Gem::Version).returns(T::Boolean) }
   def satisfies_version?(version); end
 
-  # pkg:gem/rbi#lib/rbi/printer.rb:901
+  # pkg:gem/rbi#lib/rbi/printer.rb:890
   sig { params(indent: ::Integer, print_locs: T::Boolean, max_line_length: T.nilable(::Integer)).returns(::String) }
   def string(indent: T.unsafe(nil), print_locs: T.unsafe(nil), max_line_length: T.unsafe(nil)); end
 end
@@ -1284,9 +1395,9 @@ class RBI::NodeWithComments < ::RBI::Node
   def version_requirements; end
 end
 
-# pkg:gem/rbi#lib/rbi/model.rb:638
+# pkg:gem/rbi#lib/rbi/model.rb:660
 class RBI::OptParam < ::RBI::Param
-  # pkg:gem/rbi#lib/rbi/model.rb:643
+  # pkg:gem/rbi#lib/rbi/model.rb:669
   sig do
     params(
       name: ::String,
@@ -1298,38 +1409,58 @@ class RBI::OptParam < ::RBI::Param
   end
   def initialize(name, value, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:640
+  # pkg:gem/rbi#lib/rbi/model.rb:689
+  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
+  def ==(other); end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:684
+  sig { override.returns(T::Boolean) }
+  def anonymous?; end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:663
+  sig { override.returns(::String) }
+  def name; end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:678
+  sig { override.returns(::String) }
+  def to_s; end
+
+  # pkg:gem/rbi#lib/rbi/model.rb:666
   sig { returns(::String) }
   def value; end
 end
 
 # @abstract
 #
-# pkg:gem/rbi#lib/rbi/model.rb:601
+# pkg:gem/rbi#lib/rbi/model.rb:609
 class RBI::Param < ::RBI::NodeWithComments
   abstract!
 
-  # pkg:gem/rbi#lib/rbi/model.rb:606
-  sig { params(name: ::String, loc: T.nilable(::RBI::Loc), comments: T.nilable(T::Array[::RBI::Comment])).void }
-  def initialize(name, loc: T.unsafe(nil), comments: T.unsafe(nil)); end
+  # pkg:gem/rbi#lib/rbi/model.rb:611
+  sig { params(loc: T.nilable(::RBI::Loc), comments: T.nilable(T::Array[::RBI::Comment])).void }
+  def initialize(loc: T.unsafe(nil), comments: T.unsafe(nil)); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:624
-  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
-  def ==(other); end
-
-  # pkg:gem/rbi#lib/rbi/model.rb:619
-  sig { returns(T::Boolean) }
+  # @abstract
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:625
+  sig { abstract.returns(T::Boolean) }
   def anonymous?; end
-
-  # pkg:gem/rbi#lib/rbi/model.rb:603
-  sig { returns(::String) }
-  def name; end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:614
-  sig { override.returns(::String) }
-  def to_s; end
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:543
+  sig { override.params(other: T.nilable(::RBI::Node)).returns(T::Boolean) }
+  def compatible_with?(other); end
+
+  # pkg:gem/rbi#lib/rbi/model.rb:616
+  sig { returns(T.nilable(::String)) }
+  def name; end
 end
 
 # pkg:gem/rbi#lib/rbi/parser.rb:7
@@ -1378,123 +1509,131 @@ class RBI::Parser
   end
 end
 
-# pkg:gem/rbi#lib/rbi/parser.rb:1003
+# pkg:gem/rbi#lib/rbi/parser.rb:1044
 class RBI::Parser::HeredocLocationVisitor < ::Prism::Visitor
-  # pkg:gem/rbi#lib/rbi/parser.rb:1005
+  # pkg:gem/rbi#lib/rbi/parser.rb:1046
   sig { params(source: ::Prism::Source, begin_offset: ::Integer, end_offset: ::Integer).void }
   def initialize(source, begin_offset, end_offset); end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:1036
+  # pkg:gem/rbi#lib/rbi/parser.rb:1077
   sig { returns(::Prism::Location) }
   def location; end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/parser.rb:1026
+  # pkg:gem/rbi#lib/rbi/parser.rb:1067
   sig { override.params(node: ::Prism::InterpolatedStringNode).void }
   def visit_interpolated_string_node(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/parser.rb:1015
+  # pkg:gem/rbi#lib/rbi/parser.rb:1056
   sig { override.params(node: ::Prism::StringNode).void }
   def visit_string_node(node); end
 
   private
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:1047
+  # pkg:gem/rbi#lib/rbi/parser.rb:1088
   sig { params(node: T.any(::Prism::InterpolatedStringNode, ::Prism::StringNode)).void }
   def handle_string_node(node); end
 end
 
-# pkg:gem/rbi#lib/rbi/parser.rb:915
+# pkg:gem/rbi#lib/rbi/parser.rb:935
 class RBI::Parser::SigBuilder < ::RBI::Parser::Visitor
-  # pkg:gem/rbi#lib/rbi/parser.rb:920
+  # pkg:gem/rbi#lib/rbi/parser.rb:940
   sig { params(content: ::String, file: ::String).void }
   def initialize(content, file:); end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:986
+  # pkg:gem/rbi#lib/rbi/parser.rb:1027
   sig { params(node: ::Prism::CallNode, value: ::String).returns(T::Boolean) }
   def allow_incompatible_override?(node, value); end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:917
+  # pkg:gem/rbi#lib/rbi/parser.rb:937
   sig { returns(::RBI::Sig) }
   def current; end
 
+  # pkg:gem/rbi#lib/rbi/parser.rb:1017
+  sig { params(node: ::Prism::Node).returns(::String) }
+  def sig_param_name(node); end
+
+  # pkg:gem/rbi#lib/rbi/parser.rb:1006
+  sig { params(node: ::Prism::CallNode).returns(T.nilable(::String)) }
+  def sig_type_argument(node); end
+
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/parser.rb:978
+  # pkg:gem/rbi#lib/rbi/parser.rb:998
   sig { override.params(node: ::Prism::AssocNode).void }
   def visit_assoc_node(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/parser.rb:928
+  # pkg:gem/rbi#lib/rbi/parser.rb:948
   sig { override.params(node: ::Prism::CallNode).void }
   def visit_call_node(node); end
 end
 
-# pkg:gem/rbi#lib/rbi/parser.rb:164
+# pkg:gem/rbi#lib/rbi/parser.rb:179
 class RBI::Parser::TreeBuilder < ::RBI::Parser::Visitor
-  # pkg:gem/rbi#lib/rbi/parser.rb:172
+  # pkg:gem/rbi#lib/rbi/parser.rb:187
   sig { params(source: ::String, comments: T::Array[::Prism::Comment], file: ::String).void }
   def initialize(source, comments:, file:); end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:169
+  # pkg:gem/rbi#lib/rbi/parser.rb:184
   sig { returns(T.nilable(::Prism::Node)) }
   def last_node; end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:166
+  # pkg:gem/rbi#lib/rbi/parser.rb:181
   sig { returns(::RBI::Tree) }
   def tree; end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:361
+  # pkg:gem/rbi#lib/rbi/parser.rb:376
   sig { params(node: ::Prism::CallNode).void }
   def visit_call_node(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/parser.rb:185
+  # pkg:gem/rbi#lib/rbi/parser.rb:200
   sig { override.params(node: ::Prism::ClassNode).void }
   def visit_class_node(node); end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:236
+  # pkg:gem/rbi#lib/rbi/parser.rb:251
   sig { params(node: T.any(::Prism::ConstantPathWriteNode, ::Prism::ConstantWriteNode)).void }
   def visit_constant_assign(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/parser.rb:229
+  # pkg:gem/rbi#lib/rbi/parser.rb:244
   sig { override.params(node: ::Prism::ConstantPathWriteNode).void }
   def visit_constant_path_write_node(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/parser.rb:221
+  # pkg:gem/rbi#lib/rbi/parser.rb:236
   sig { override.params(node: ::Prism::ConstantWriteNode).void }
   def visit_constant_write_node(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/parser.rb:291
+  # pkg:gem/rbi#lib/rbi/parser.rb:306
   sig { override.params(node: ::Prism::DefNode).void }
   def visit_def_node(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/parser.rb:313
+  # pkg:gem/rbi#lib/rbi/parser.rb:328
   sig { override.params(node: ::Prism::ModuleNode).void }
   def visit_module_node(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/parser.rb:332
+  # pkg:gem/rbi#lib/rbi/parser.rb:347
   sig { override.params(node: ::Prism::ProgramNode).void }
   def visit_program_node(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/parser.rb:344
+  # pkg:gem/rbi#lib/rbi/parser.rb:359
   sig { override.params(node: ::Prism::SingletonClassNode).void }
   def visit_singleton_class_node(node); end
 
@@ -1502,49 +1641,49 @@ class RBI::Parser::TreeBuilder < ::RBI::Parser::Visitor
 
   # Collect all the remaining comments within a node
   #
-  # pkg:gem/rbi#lib/rbi/parser.rb:539
+  # pkg:gem/rbi#lib/rbi/parser.rb:554
   sig { params(node: ::Prism::Node).void }
   def collect_dangling_comments(node); end
 
   # Collect all the remaining comments after visiting the tree
   #
-  # pkg:gem/rbi#lib/rbi/parser.rb:557
+  # pkg:gem/rbi#lib/rbi/parser.rb:572
   sig { void }
   def collect_orphan_comments; end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:580
+  # pkg:gem/rbi#lib/rbi/parser.rb:595
   sig { returns(::RBI::Tree) }
   def current_scope; end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:585
+  # pkg:gem/rbi#lib/rbi/parser.rb:600
   sig { returns(T::Array[::RBI::Sig]) }
   def current_sigs; end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:592
+  # pkg:gem/rbi#lib/rbi/parser.rb:607
   sig { params(sigs: T::Array[::RBI::Sig]).returns(T::Array[::RBI::Comment]) }
   def detach_comments_from_sigs(sigs); end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:604
+  # pkg:gem/rbi#lib/rbi/parser.rb:619
   sig { params(node: ::Prism::Node).returns(T::Array[::RBI::Comment]) }
   def node_comments(node); end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:666
+  # pkg:gem/rbi#lib/rbi/parser.rb:681
   sig { params(node: ::Prism::Comment).returns(::RBI::Comment) }
   def parse_comment(node); end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:699
+  # pkg:gem/rbi#lib/rbi/parser.rb:714
   sig { params(node: T.nilable(::Prism::Node)).returns(T::Array[::RBI::Param]) }
   def parse_params(node); end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:673
+  # pkg:gem/rbi#lib/rbi/parser.rb:688
   sig { params(node: T.nilable(::Prism::Node)).returns(T::Array[::RBI::Arg]) }
   def parse_send_args(node); end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:765
+  # pkg:gem/rbi#lib/rbi/parser.rb:785
   sig { params(node: ::Prism::CallNode).returns(::RBI::Sig) }
   def parse_sig(node); end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:774
+  # pkg:gem/rbi#lib/rbi/parser.rb:794
   sig do
     params(
       node: T.any(::Prism::ConstantPathWriteNode, ::Prism::ConstantWriteNode)
@@ -1552,27 +1691,27 @@ class RBI::Parser::TreeBuilder < ::RBI::Parser::Visitor
   end
   def parse_struct(node); end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:822
+  # pkg:gem/rbi#lib/rbi/parser.rb:842
   sig { params(send: ::Prism::CallNode).void }
   def parse_tstruct_field(send); end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:859
+  # pkg:gem/rbi#lib/rbi/parser.rb:879
   sig { params(name: ::String, node: ::Prism::Node).returns(::RBI::Visibility) }
   def parse_visibility(name, node); end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:873
+  # pkg:gem/rbi#lib/rbi/parser.rb:893
   sig { void }
   def separate_header_comments; end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:883
+  # pkg:gem/rbi#lib/rbi/parser.rb:903
   sig { void }
   def set_root_tree_loc; end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:902
+  # pkg:gem/rbi#lib/rbi/parser.rb:922
   sig { params(node: T.nilable(::Prism::Node)).returns(T::Boolean) }
   def t_enum_value?(node); end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:897
+  # pkg:gem/rbi#lib/rbi/parser.rb:917
   sig { params(node: T.nilable(::Prism::Node)).returns(T::Boolean) }
   def type_variable_definition?(node); end
 end
@@ -1585,9 +1724,13 @@ class RBI::Parser::Visitor < ::Prism::Visitor
 
   private
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:143
+  # pkg:gem/rbi#lib/rbi/parser.rb:158
   sig { params(node: ::Prism::Node).returns(::Prism::Location) }
   def adjust_prism_location_for_heredoc(node); end
+
+  # pkg:gem/rbi#lib/rbi/parser.rb:149
+  sig { params(node: ::Prism::Node).returns(T::Boolean) }
+  def braceless_shape?(node); end
 
   # pkg:gem/rbi#lib/rbi/parser.rb:126
   sig { params(node: ::Prism::Node).returns(::RBI::Loc) }
@@ -1601,13 +1744,17 @@ class RBI::Parser::Visitor < ::Prism::Visitor
   sig { params(node: ::Prism::Node).returns(::String) }
   def node_string!(node); end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:154
+  # pkg:gem/rbi#lib/rbi/parser.rb:169
   sig { params(node: T.nilable(::Prism::Node)).returns(T::Boolean) }
   def self?(node); end
 
-  # pkg:gem/rbi#lib/rbi/parser.rb:159
+  # pkg:gem/rbi#lib/rbi/parser.rb:174
   sig { params(node: T.nilable(::Prism::Node)).returns(T::Boolean) }
   def t_sig_without_runtime?(node); end
+
+  # pkg:gem/rbi#lib/rbi/parser.rb:143
+  sig { params(node: ::Prism::Node).returns(::String) }
+  def type_string(node); end
 end
 
 # pkg:gem/rbi#lib/rbi/printer.rb:7
@@ -1698,41 +1845,41 @@ class RBI::Printer < ::RBI::Visitor
 
   private
 
-  # pkg:gem/rbi#lib/rbi/printer.rb:720
+  # pkg:gem/rbi#lib/rbi/printer.rb:708
   sig { params(node: ::RBI::Node).returns(T::Boolean) }
   def oneline?(node); end
 
-  # pkg:gem/rbi#lib/rbi/printer.rb:678
+  # pkg:gem/rbi#lib/rbi/printer.rb:676
   sig { params(node: ::RBI::Node).void }
   def print_blank_line_before(node); end
 
-  # pkg:gem/rbi#lib/rbi/printer.rb:688
+  # pkg:gem/rbi#lib/rbi/printer.rb:686
   sig { params(node: ::RBI::Node).void }
   def print_loc(node); end
 
-  # pkg:gem/rbi#lib/rbi/printer.rb:694
+  # pkg:gem/rbi#lib/rbi/printer.rb:692
   sig { params(node: ::RBI::Param, last: T::Boolean).void }
   def print_param_comment_leading_space(node, last:); end
 
-  # pkg:gem/rbi#lib/rbi/printer.rb:779
+  # pkg:gem/rbi#lib/rbi/printer.rb:767
   sig { params(node: ::RBI::Sig).void }
   def print_sig_as_block(node); end
 
-  # pkg:gem/rbi#lib/rbi/printer.rb:749
+  # pkg:gem/rbi#lib/rbi/printer.rb:737
   sig { params(node: ::RBI::Sig).void }
   def print_sig_as_line(node); end
 
-  # pkg:gem/rbi#lib/rbi/printer.rb:712
+  # pkg:gem/rbi#lib/rbi/printer.rb:700
   sig { params(node: ::RBI::SigParam, last: T::Boolean).void }
   def print_sig_param_comment_leading_space(node, last:); end
 
-  # pkg:gem/rbi#lib/rbi/printer.rb:849
+  # pkg:gem/rbi#lib/rbi/printer.rb:837
   sig { params(node: ::RBI::Sig).returns(T::Array[::String]) }
   def sig_modifiers(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:489
+  # pkg:gem/rbi#lib/rbi/printer.rb:487
   sig { override.params(node: ::RBI::Arg).void }
   def visit_arg(node); end
 
@@ -1766,7 +1913,7 @@ class RBI::Printer < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:408
+  # pkg:gem/rbi#lib/rbi/printer.rb:407
   sig { override.params(node: ::RBI::BlockParam).void }
   def visit_block_param(node); end
 
@@ -1784,7 +1931,7 @@ class RBI::Printer < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:654
+  # pkg:gem/rbi#lib/rbi/printer.rb:652
   sig { override.params(node: ::RBI::ConflictTree).void }
   def visit_conflict_tree(node); end
 
@@ -1796,49 +1943,49 @@ class RBI::Printer < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:421
+  # pkg:gem/rbi#lib/rbi/printer.rb:419
   sig { override.params(node: ::RBI::Extend).void }
   def visit_extend(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:623
+  # pkg:gem/rbi#lib/rbi/printer.rb:621
   sig { override.params(node: ::RBI::Group).void }
   def visit_group(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:607
+  # pkg:gem/rbi#lib/rbi/printer.rb:605
   sig { override.params(node: ::RBI::Helper).void }
   def visit_helper(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:415
+  # pkg:gem/rbi#lib/rbi/printer.rb:413
   sig { override.params(node: ::RBI::Include).void }
   def visit_include(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:495
+  # pkg:gem/rbi#lib/rbi/printer.rb:493
   sig { override.params(node: ::RBI::KwArg).void }
   def visit_kw_arg(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:393
+  # pkg:gem/rbi#lib/rbi/printer.rb:389
   sig { override.params(node: ::RBI::KwOptParam).void }
   def visit_kw_opt_param(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:386
+  # pkg:gem/rbi#lib/rbi/printer.rb:383
   sig { override.params(node: ::RBI::KwParam).void }
   def visit_kw_param(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:401
+  # pkg:gem/rbi#lib/rbi/printer.rb:395
   sig { override.params(node: ::RBI::KwRestParam).void }
   def visit_kw_rest_param(node); end
 
@@ -1850,11 +1997,11 @@ class RBI::Printer < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:617
+  # pkg:gem/rbi#lib/rbi/printer.rb:615
   sig { override.params(node: ::RBI::MixesInClassMethods).void }
   def visit_mixes_in_class_methods(node); end
 
-  # pkg:gem/rbi#lib/rbi/printer.rb:426
+  # pkg:gem/rbi#lib/rbi/printer.rb:424
   sig { params(node: ::RBI::Mixin).void }
   def visit_mixin(node); end
 
@@ -1866,25 +2013,31 @@ class RBI::Printer < ::RBI::Visitor
 
   # @override
   #
+  # pkg:gem/rbi#lib/rbi/printer.rb:401
+  sig { override.params(node: ::RBI::NoKwParam).void }
+  def visit_no_kw_param(node); end
+
+  # @override
+  #
   # pkg:gem/rbi#lib/rbi/printer.rb:371
   sig { override.params(node: ::RBI::OptParam).void }
   def visit_opt_param(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:456
+  # pkg:gem/rbi#lib/rbi/printer.rb:454
   sig { override.params(node: ::RBI::Private).void }
   def visit_private(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:450
+  # pkg:gem/rbi#lib/rbi/printer.rb:448
   sig { override.params(node: ::RBI::Protected).void }
   def visit_protected(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:444
+  # pkg:gem/rbi#lib/rbi/printer.rb:442
   sig { override.params(node: ::RBI::Public).void }
   def visit_public(node); end
 
@@ -1902,13 +2055,13 @@ class RBI::Printer < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:644
+  # pkg:gem/rbi#lib/rbi/printer.rb:642
   sig { override.params(node: ::RBI::RequiresAncestor).void }
   def visit_requires_ancestor(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:379
+  # pkg:gem/rbi#lib/rbi/printer.rb:377
   sig { override.params(node: ::RBI::RestParam).void }
   def visit_rest_param(node); end
 
@@ -1922,7 +2075,7 @@ class RBI::Printer < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:664
+  # pkg:gem/rbi#lib/rbi/printer.rb:662
   sig { override.params(node: ::RBI::ScopeConflict).void }
   def visit_scope_conflict(node); end
 
@@ -1932,19 +2085,19 @@ class RBI::Printer < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:471
+  # pkg:gem/rbi#lib/rbi/printer.rb:469
   sig { override.params(node: ::RBI::Send).void }
   def visit_send(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:503
+  # pkg:gem/rbi#lib/rbi/printer.rb:501
   sig { override.params(node: ::RBI::Sig).void }
   def visit_sig(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:524
+  # pkg:gem/rbi#lib/rbi/printer.rb:522
   sig { override.params(node: ::RBI::SigParam).void }
   def visit_sig_param(node); end
 
@@ -1960,25 +2113,25 @@ class RBI::Printer < ::RBI::Visitor
   sig { override.params(node: ::RBI::Struct).void }
   def visit_struct(node); end
 
-  # pkg:gem/rbi#lib/rbi/printer.rb:549
+  # pkg:gem/rbi#lib/rbi/printer.rb:547
   sig { params(node: ::RBI::TStructField).void }
   def visit_t_struct_field(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:568
+  # pkg:gem/rbi#lib/rbi/printer.rb:566
   sig { override.params(node: ::RBI::TEnum).void }
   def visit_tenum(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:574
+  # pkg:gem/rbi#lib/rbi/printer.rb:572
   sig { override.params(node: ::RBI::TEnumBlock).void }
   def visit_tenum_block(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:587
+  # pkg:gem/rbi#lib/rbi/printer.rb:585
   sig { override.params(node: ::RBI::TEnumValue).void }
   def visit_tenum_value(node); end
 
@@ -1990,40 +2143,40 @@ class RBI::Printer < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:532
+  # pkg:gem/rbi#lib/rbi/printer.rb:530
   sig { override.params(node: ::RBI::TStruct).void }
   def visit_tstruct(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:538
+  # pkg:gem/rbi#lib/rbi/printer.rb:536
   sig { override.params(node: ::RBI::TStructConst).void }
   def visit_tstruct_const(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:544
+  # pkg:gem/rbi#lib/rbi/printer.rb:542
   sig { override.params(node: ::RBI::TStructProp).void }
   def visit_tstruct_prop(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:597
+  # pkg:gem/rbi#lib/rbi/printer.rb:595
   sig { override.params(node: ::RBI::TypeMember).void }
   def visit_type_member(node); end
 
-  # pkg:gem/rbi#lib/rbi/printer.rb:461
+  # pkg:gem/rbi#lib/rbi/printer.rb:459
   sig { params(node: ::RBI::Visibility).void }
   def visit_visibility(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/printer.rb:630
+  # pkg:gem/rbi#lib/rbi/printer.rb:628
   sig { override.params(node: ::RBI::VisibilityGroup).void }
   def visit_visibility_group(node); end
 end
 
-# pkg:gem/rbi#lib/rbi/printer.rb:846
+# pkg:gem/rbi#lib/rbi/printer.rb:834
 RBI::Printer::EMPTY_MODIFIERS = T.let(T.unsafe(nil), Array)
 
 # pkg:gem/rbi#lib/rbi/printer.rb:10
@@ -2037,9 +2190,9 @@ RBI::Printer::MAX_CACHED_INDENT = T.let(T.unsafe(nil), Integer)
 # pkg:gem/rbi#lib/rbi/printer.rb:5
 class RBI::PrinterError < ::RBI::Error; end
 
-# pkg:gem/rbi#lib/rbi/model.rb:821
+# pkg:gem/rbi#lib/rbi/model.rb:970
 class RBI::Private < ::RBI::Visibility
-  # pkg:gem/rbi#lib/rbi/model.rb:823
+  # pkg:gem/rbi#lib/rbi/model.rb:972
   sig do
     params(
       loc: T.nilable(::RBI::Loc),
@@ -2050,9 +2203,9 @@ class RBI::Private < ::RBI::Visibility
   def initialize(loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 end
 
-# pkg:gem/rbi#lib/rbi/model.rb:813
+# pkg:gem/rbi#lib/rbi/model.rb:962
 class RBI::Protected < ::RBI::Visibility
-  # pkg:gem/rbi#lib/rbi/model.rb:815
+  # pkg:gem/rbi#lib/rbi/model.rb:964
   sig do
     params(
       loc: T.nilable(::RBI::Loc),
@@ -2063,9 +2216,9 @@ class RBI::Protected < ::RBI::Visibility
   def initialize(loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 end
 
-# pkg:gem/rbi#lib/rbi/model.rb:802
+# pkg:gem/rbi#lib/rbi/model.rb:951
 class RBI::Public < ::RBI::Visibility
-  # pkg:gem/rbi#lib/rbi/model.rb:804
+  # pkg:gem/rbi#lib/rbi/model.rb:953
   sig do
     params(
       loc: T.nilable(::RBI::Loc),
@@ -2078,7 +2231,7 @@ end
 
 # Shared default instance to avoid allocating a new Public on every Method/Attr creation.
 #
-# pkg:gem/rbi#lib/rbi/model.rb:810
+# pkg:gem/rbi#lib/rbi/model.rb:959
 RBI::Public::DEFAULT = T.let(T.unsafe(nil), RBI::Public)
 
 # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:5
@@ -2086,33 +2239,37 @@ module RBI::RBS; end
 
 # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:6
 class RBI::RBS::MethodTypeTranslator
-  # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:22
-  sig { params(method: ::RBI::Method).void }
-  def initialize(method); end
+  # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:38
+  sig { params(method: ::RBI::Method, options: ::RBI::RBS::MethodTypeTranslator::Options).void }
+  def initialize(method, options: T.unsafe(nil)); end
 
-  # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:19
+  # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:35
   sig { returns(::RBI::Sig) }
   def result; end
 
-  # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:28
+  # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:47
   sig { params(type: ::RBS::MethodType).void }
   def visit(type); end
 
   private
 
-  # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:100
+  # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:136
+  sig { params(param: ::RBI::Param).returns(T.nilable(::String)) }
+  def anonymous_param_name(param); end
+
+  # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:121
   sig { params(param: ::RBS::Types::Function::Param, index: ::Integer).returns(::RBI::SigParam) }
   def translate_function_param(param, index); end
 
-  # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:115
+  # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:148
   sig { params(type: T.untyped).returns(::RBI::Type) }
   def translate_type(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:42
+  # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:63
   sig { params(type: ::RBS::Types::Block).void }
   def visit_block_type(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:57
+  # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:78
   sig { params(type: ::RBS::Types::Function).void }
   def visit_function_type(type); end
 
@@ -2126,8 +2283,59 @@ end
 # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:7
 class RBI::RBS::MethodTypeTranslator::Error < ::RBI::Error; end
 
+# pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:18
+class RBI::RBS::MethodTypeTranslator::Options
+  # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:23
+  sig { params(erase_generic_types: T::Boolean).void }
+  def initialize(erase_generic_types: T.unsafe(nil)); end
+
+  # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:20
+  sig { returns(T::Boolean) }
+  def erase_generic_types; end
+
+  class << self
+    # pkg:gem/rbi#lib/rbi/rbs/method_type_translator.rb:30
+    sig { returns(::RBI::RBS::MethodTypeTranslator::Options) }
+    def default; end
+  end
+end
+
 # pkg:gem/rbi#lib/rbi/rbs/type_translator.rb:6
 class RBI::RBS::TypeTranslator
+  # pkg:gem/rbi#lib/rbi/rbs/type_translator.rb:41
+  sig { params(options: ::RBI::RBS::MethodTypeTranslator::Options).void }
+  def initialize(options: T.unsafe(nil)); end
+
+  # pkg:gem/rbi#lib/rbi/rbs/type_translator.rb:46
+  sig do
+    params(
+      type: T.any(::RBS::Types::Alias, ::RBS::Types::Bases::Any, ::RBS::Types::Bases::Bool, ::RBS::Types::Bases::Bottom, ::RBS::Types::Bases::Class, ::RBS::Types::Bases::Instance, ::RBS::Types::Bases::Nil, ::RBS::Types::Bases::Self, ::RBS::Types::Bases::Top, ::RBS::Types::Bases::Void, ::RBS::Types::ClassInstance, ::RBS::Types::ClassSingleton, ::RBS::Types::Function, ::RBS::Types::Interface, ::RBS::Types::Intersection, ::RBS::Types::Literal, ::RBS::Types::Optional, ::RBS::Types::Proc, ::RBS::Types::Record, ::RBS::Types::Tuple, ::RBS::Types::Union, ::RBS::Types::UntypedFunction, ::RBS::Types::Variable)
+    ).returns(::RBI::Type)
+  end
+  def translate(type); end
+
+  private
+
+  # pkg:gem/rbi#lib/rbi/rbs/type_translator.rb:225
+  sig { params(type_name: ::String).returns(::String) }
+  def erase_t_generic_type(type_name); end
+
+  # pkg:gem/rbi#lib/rbi/rbs/type_translator.rb:138
+  sig { params(type: ::RBS::Types::ClassInstance).returns(::RBI::Type) }
+  def translate_class_instance(type); end
+
+  # pkg:gem/rbi#lib/rbi/rbs/type_translator.rb:152
+  sig { params(type: ::RBS::Types::Function).returns(::RBI::Type) }
+  def translate_function(type); end
+
+  # pkg:gem/rbi#lib/rbi/rbs/type_translator.rb:220
+  sig { params(type_name: ::String).returns(::String) }
+  def translate_t_generic_type(type_name); end
+
+  # pkg:gem/rbi#lib/rbi/rbs/type_translator.rb:126
+  sig { params(type: ::RBS::Types::Alias).returns(::RBI::Type) }
+  def translate_type_alias(type); end
+
   class << self
     # pkg:gem/rbi#lib/rbi/rbs/type_translator.rb:33
     sig do
@@ -2136,26 +2344,22 @@ class RBI::RBS::TypeTranslator
       ).returns(::RBI::Type)
     end
     def translate(type); end
-
-    private
-
-    # pkg:gem/rbi#lib/rbi/rbs/type_translator.rb:117
-    sig { params(type: ::RBS::Types::ClassInstance).returns(::RBI::Type) }
-    def translate_class_instance(type); end
-
-    # pkg:gem/rbi#lib/rbi/rbs/type_translator.rb:125
-    sig { params(type: ::RBS::Types::Function).returns(::RBI::Type) }
-    def translate_function(type); end
-
-    # pkg:gem/rbi#lib/rbi/rbs/type_translator.rb:172
-    sig { params(type_name: ::String).returns(::String) }
-    def translate_t_generic_type(type_name); end
-
-    # pkg:gem/rbi#lib/rbi/rbs/type_translator.rb:105
-    sig { params(type: ::RBS::Types::Alias).returns(::RBI::Type) }
-    def translate_type_alias(type); end
   end
 end
+
+# pkg:gem/rbi#lib/rbi/rbs/type_translator.rb:211
+RBI::RBS::TypeTranslator::GENERIC_TYPE_TO_SORBET_GENERIC_TYPE = T.let(T.unsafe(nil), Hash)
+
+# pkg:gem/rbi#lib/rbi/rbs/type_translator.rb:38
+RBI::RBS::TypeTranslator::Options = RBI::RBS::MethodTypeTranslator::Options
+
+# pkg:gem/rbi#lib/rbi/rbs/type_translator.rb:198
+RBI::RBS::TypeTranslator::RUNTIME_GENERIC_TYPES = T.let(T.unsafe(nil), Array)
+
+RBI::RBS::TypeTranslator::RbsType = T.type_alias { T.any(::RBS::Types::Alias, ::RBS::Types::Bases::Any, ::RBS::Types::Bases::Bool, ::RBS::Types::Bases::Bottom, ::RBS::Types::Bases::Class, ::RBS::Types::Bases::Instance, ::RBS::Types::Bases::Nil, ::RBS::Types::Bases::Self, ::RBS::Types::Bases::Top, ::RBS::Types::Bases::Void, ::RBS::Types::ClassInstance, ::RBS::Types::ClassSingleton, ::RBS::Types::Function, ::RBS::Types::Interface, ::RBS::Types::Intersection, ::RBS::Types::Literal, ::RBS::Types::Optional, ::RBS::Types::Proc, ::RBS::Types::Record, ::RBS::Types::Tuple, ::RBS::Types::Union, ::RBS::Types::UntypedFunction, ::RBS::Types::Variable) }
+
+# pkg:gem/rbi#lib/rbi/rbs/type_translator.rb:215
+RBI::RBS::TypeTranslator::SORBET_GENERIC_TYPE_TO_GENERIC_TYPE = T.let(T.unsafe(nil), Hash)
 
 # A comment representing a RBS type prefixed with `#:`
 #
@@ -2168,23 +2372,24 @@ end
 
 # pkg:gem/rbi#lib/rbi/rbs_printer.rb:5
 class RBI::RBSPrinter < ::RBI::Visitor
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:30
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:31
   sig do
     params(
       out: T.any(::IO, ::StringIO),
       indent: ::Integer,
       print_locs: T::Boolean,
       positional_names: T::Boolean,
-      max_line_length: T.nilable(::Integer)
+      max_line_length: T.nilable(::Integer),
+      force_multiline_signatures: T::Boolean
     ).void
   end
-  def initialize(out: T.unsafe(nil), indent: T.unsafe(nil), print_locs: T.unsafe(nil), positional_names: T.unsafe(nil), max_line_length: T.unsafe(nil)); end
+  def initialize(out: T.unsafe(nil), indent: T.unsafe(nil), print_locs: T.unsafe(nil), positional_names: T.unsafe(nil), max_line_length: T.unsafe(nil), force_multiline_signatures: T.unsafe(nil)); end
 
   # pkg:gem/rbi#lib/rbi/rbs_printer.rb:15
   sig { returns(::Integer) }
   def current_indent; end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:49
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:58
   sig { void }
   def dedent; end
 
@@ -2194,7 +2399,7 @@ class RBI::RBSPrinter < ::RBI::Visitor
   # pkg:gem/rbi#lib/rbi/rbs_printer.rb:9
   def in_visibility_group=(_arg0); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:44
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:53
   sig { void }
   def indent; end
 
@@ -2215,11 +2420,11 @@ class RBI::RBSPrinter < ::RBI::Visitor
 
   # Print a string without indentation nor `\n` at the end.
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:55
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:64
   sig { params(string: ::String).void }
   def print(string); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:302
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:311
   sig { params(node: ::RBI::Attr, sig: ::RBI::Sig).void }
   def print_attr_sig(node, sig); end
 
@@ -2230,329 +2435,335 @@ class RBI::RBSPrinter < ::RBI::Visitor
   # pkg:gem/rbi#lib/rbi/rbs_printer.rb:9
   def print_locs=(_arg0); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:400
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:409
   sig { params(node: ::RBI::Method, sig: ::RBI::Sig).void }
   def print_method_sig(node, sig); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:417
-  sig { params(node: ::RBI::Method, sig: ::RBI::Sig).void }
-  def print_method_sig_inline(node, sig); end
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:491
+  sig { params(sig_param: T.nilable(::RBI::SigParam)).void }
+  def print_method_sig_block(sig_param); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:479
-  sig { params(node: ::RBI::Method, sig: ::RBI::Sig).void }
-  def print_method_sig_multiline(node, sig); end
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:426
+  sig { params(node: ::RBI::Method, sig: ::RBI::Sig, multiline: T::Boolean).void }
+  def print_method_sig_content(node, sig, multiline:); end
 
   # Print a string with indentation and `\n` at the end.
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:75
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:84
   sig { params(string: ::String).void }
   def printl(string); end
 
   # Print a string without indentation but with a `\n` at the end.
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:61
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:70
   sig { params(string: T.nilable(::String)).void }
   def printn(string = T.unsafe(nil)); end
 
   # Print a string with indentation but without a `\n` at the end.
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:68
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:77
   sig { params(string: T.nilable(::String)).void }
   def printt(string = T.unsafe(nil)); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:82
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:91
   sig { override.params(nodes: T::Array[::RBI::Node]).void }
   def visit_all(nodes); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:680
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:662
   sig { override.params(node: ::RBI::Arg).void }
   def visit_arg(node); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:270
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:279
   sig { params(node: ::RBI::Attr).void }
   def visit_attr(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:253
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:262
   sig { override.params(node: ::RBI::AttrAccessor).void }
   def visit_attr_accessor(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:259
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:268
   sig { override.params(node: ::RBI::AttrReader).void }
   def visit_attr_reader(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:265
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:274
   sig { override.params(node: ::RBI::AttrWriter).void }
   def visit_attr_writer(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:124
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:133
   sig { override.params(node: ::RBI::BlankLine).void }
   def visit_blank_line(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:612
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:594
   sig { override.params(node: ::RBI::BlockParam).void }
   def visit_block_param(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:144
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:153
   sig { override.params(node: ::RBI::Class).void }
   def visit_class(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:107
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:116
   sig { override.params(node: ::RBI::Comment).void }
   def visit_comment(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:816
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:798
   sig { override.params(node: ::RBI::ConflictTree).void }
   def visit_conflict_tree(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:237
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:246
   sig { override.params(node: ::RBI::Const).void }
   def visit_const(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:624
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:606
   sig { override.params(node: ::RBI::Extend).void }
   def visit_extend(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:94
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:103
   sig { override.params(file: ::RBI::File).void }
   def visit_file(file); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:789
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:771
   sig { override.params(node: ::RBI::Group).void }
   def visit_group(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:777
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:759
   sig { override.params(node: ::RBI::Helper).void }
   def visit_helper(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:618
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:600
   sig { override.params(node: ::RBI::Include).void }
   def visit_include(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:686
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:668
   sig { override.params(node: ::RBI::KwArg).void }
   def visit_kw_arg(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:600
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:575
   sig { override.params(node: ::RBI::KwOptParam).void }
   def visit_kw_opt_param(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:594
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:569
   sig { override.params(node: ::RBI::KwParam).void }
   def visit_kw_param(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:606
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:581
   sig { override.params(node: ::RBI::KwRestParam).void }
   def visit_kw_rest_param(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:325
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:334
   sig { override.params(node: ::RBI::Method).void }
   def visit_method(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:783
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:765
   sig { override.params(node: ::RBI::MixesInClassMethods).void }
   def visit_mixes_in_class_methods(node); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:629
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:611
   sig { params(node: ::RBI::Mixin).void }
   def visit_mixin(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:138
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:147
   sig { override.params(node: ::RBI::Module).void }
   def visit_module(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:574
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:588
+  sig { override.params(node: ::RBI::NoKwParam).void }
+  def visit_no_kw_param(node); end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:552
   sig { override.params(node: ::RBI::OptParam).void }
   def visit_opt_param(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:659
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:641
   sig { override.params(node: ::RBI::Private).void }
   def visit_private(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:653
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:635
   sig { override.params(node: ::RBI::Protected).void }
   def visit_protected(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:647
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:629
   sig { override.params(node: ::RBI::Public).void }
   def visit_public(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:564
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:542
   sig { override.params(node: ::RBI::ReqParam).void }
   def visit_req_param(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:810
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:792
   sig { override.params(node: ::RBI::RequiresAncestor).void }
   def visit_requires_ancestor(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:584
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:562
   sig { override.params(node: ::RBI::RestParam).void }
   def visit_rest_param(node); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:161
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:170
   sig { params(node: ::RBI::Scope).void }
   def visit_scope(node); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:224
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:233
   sig { params(node: ::RBI::Scope).void }
   def visit_scope_body(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:826
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:808
   sig { override.params(node: ::RBI::ScopeConflict).void }
   def visit_scope_conflict(node); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:171
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:180
   sig { params(node: ::RBI::Scope).void }
   def visit_scope_header(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:674
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:656
   sig { override.params(node: ::RBI::Send).void }
   def visit_send(node); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:545
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:523
   sig { params(node: ::RBI::Sig).void }
   def visit_sig(node); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:558
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:536
   sig { params(node: ::RBI::SigParam).void }
   def visit_sig_param(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:156
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:165
   sig { override.params(node: ::RBI::SingletonClass).void }
   def visit_singleton_class(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:150
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:159
   sig { override.params(node: ::RBI::Struct).void }
   def visit_struct(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:743
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:725
   sig { override.params(node: ::RBI::TEnum).void }
   def visit_tenum(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:749
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:731
   sig { override.params(node: ::RBI::TEnumBlock).void }
   def visit_tenum_block(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:755
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:737
   sig { override.params(node: ::RBI::TEnumValue).void }
   def visit_tenum_value(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:130
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:139
   sig { override.params(node: ::RBI::Tree).void }
   def visit_tree(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:692
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:674
   sig { override.params(node: ::RBI::TStruct).void }
   def visit_tstruct(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:727
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:709
   sig { override.params(node: ::RBI::TStructConst).void }
   def visit_tstruct_const(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:735
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:717
   sig { override.params(node: ::RBI::TStructProp).void }
   def visit_tstruct_prop(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:771
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:753
   sig { override.params(node: ::RBI::TypeMember).void }
   def visit_type_member(node); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:664
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:646
   sig { params(node: ::RBI::Visibility).void }
   def visit_visibility(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:796
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:778
   sig { override.params(node: ::RBI::VisibilityGroup).void }
   def visit_visibility_group(node); end
 
   private
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:929
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:908
   sig { params(node: ::RBI::Node).returns(T::Boolean) }
   def oneline?(node); end
 
@@ -2560,31 +2771,31 @@ class RBI::RBSPrinter < ::RBI::Visitor
   #
   # Returns `nil` is the string is not a `T.let`.
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:963
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:942
   sig { params(code: T.nilable(::String)).returns(T.nilable(::String)) }
   def parse_t_let(code); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:951
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:930
   sig { params(type: T.any(::RBI::Type, ::String)).returns(::RBI::Type) }
   def parse_type(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:842
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:824
   sig { params(node: ::RBI::Node).void }
   def print_blank_line_before(node); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:861
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:843
   sig { params(node: ::RBI::Node).void }
   def print_loc(node); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:903
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:892
   sig { params(node: ::RBI::Param, last: T::Boolean).void }
   def print_param_comment_leading_space(node, last:); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:867
-  sig { params(node: ::RBI::Method, param: ::RBI::SigParam).void }
-  def print_sig_param(node, param); end
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:849
+  sig { params(sig_param: ::RBI::SigParam, method_param: ::RBI::Param).void }
+  def print_sig_param(sig_param, method_param); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:921
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:900
   sig { params(node: ::RBI::SigParam, last: T::Boolean).void }
   def print_sig_param_comment_leading_space(node, last:); end
 end
@@ -2597,7 +2808,7 @@ class RBI::ReplaceNodeError < ::RBI::Error; end
 
 # pkg:gem/rbi#lib/rbi/model.rb:630
 class RBI::ReqParam < ::RBI::Param
-  # pkg:gem/rbi#lib/rbi/model.rb:632
+  # pkg:gem/rbi#lib/rbi/model.rb:636
   sig do
     params(
       name: ::String,
@@ -2607,13 +2818,35 @@ class RBI::ReqParam < ::RBI::Param
     ).void
   end
   def initialize(name, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
+
+  # pkg:gem/rbi#lib/rbi/model.rb:655
+  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
+  def ==(other); end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:650
+  sig { override.returns(T::Boolean) }
+  def anonymous?; end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:633
+  sig { override.returns(::String) }
+  def name; end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:644
+  sig { override.returns(::String) }
+  def to_s; end
 end
 
-# pkg:gem/rbi#lib/rbi/model.rb:1250
+# pkg:gem/rbi#lib/rbi/model.rb:1412
 class RBI::RequiresAncestor < ::RBI::NodeWithComments
   include ::RBI::Indexable
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1255
+  # pkg:gem/rbi#lib/rbi/model.rb:1417
   sig { params(name: ::String, loc: T.nilable(::RBI::Loc), comments: T.nilable(T::Array[::RBI::Comment])).void }
   def initialize(name, loc: T.unsafe(nil), comments: T.unsafe(nil)); end
 
@@ -2623,23 +2856,23 @@ class RBI::RequiresAncestor < ::RBI::NodeWithComments
   sig { override.returns(T::Array[::String]) }
   def index_ids; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1252
+  # pkg:gem/rbi#lib/rbi/model.rb:1414
   sig { returns(::String) }
   def name; end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:1262
+  # pkg:gem/rbi#lib/rbi/model.rb:1424
   sig { override.returns(::String) }
   def to_s; end
 end
 
-# pkg:gem/rbi#lib/rbi/model.rb:650
+# pkg:gem/rbi#lib/rbi/model.rb:694
 class RBI::RestParam < ::RBI::Param
-  # pkg:gem/rbi#lib/rbi/model.rb:652
+  # pkg:gem/rbi#lib/rbi/model.rb:700
   sig do
     params(
-      name: ::String,
+      name: T.nilable(::String),
       loc: T.nilable(::RBI::Loc),
       comments: T.nilable(T::Array[::RBI::Comment]),
       block: T.nilable(T.proc.params(node: ::RBI::RestParam).void)
@@ -2647,9 +2880,25 @@ class RBI::RestParam < ::RBI::Param
   end
   def initialize(name, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 
+  # pkg:gem/rbi#lib/rbi/model.rb:719
+  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
+  def ==(other); end
+
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:659
+  # pkg:gem/rbi#lib/rbi/model.rb:714
+  sig { override.returns(T::Boolean) }
+  def anonymous?; end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:697
+  sig { override.returns(T.nilable(::String)) }
+  def name; end
+
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:708
   sig { override.returns(::String) }
   def to_s; end
 end
@@ -2679,7 +2928,7 @@ class RBI::Rewriters::AddSigTemplates < ::RBI::Visitor
   sig { params(method: ::RBI::Method).void }
   def add_method_sig(method); end
 
-  # pkg:gem/rbi#lib/rbi/rewriters/add_sig_templates.rb:55
+  # pkg:gem/rbi#lib/rbi/rewriters/add_sig_templates.rb:71
   sig { params(node: ::RBI::NodeWithComments).void }
   def add_todo_comment(node); end
 end
@@ -3292,23 +3541,27 @@ end
 #
 # pkg:gem/rbi#lib/rbi/rewriters/translate_rbs_sigs.rb:7
 class RBI::Rewriters::TranslateRBSSigs < ::RBI::Visitor
+  # pkg:gem/rbi#lib/rbi/rewriters/translate_rbs_sigs.rb:11
+  sig { void }
+  def initialize; end
+
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rewriters/translate_rbs_sigs.rb:12
+  # pkg:gem/rbi#lib/rbi/rewriters/translate_rbs_sigs.rb:18
   sig { override.params(node: T.nilable(::RBI::Node)).void }
   def visit(node); end
 
   private
 
-  # pkg:gem/rbi#lib/rbi/rewriters/translate_rbs_sigs.rb:34
+  # pkg:gem/rbi#lib/rbi/rewriters/translate_rbs_sigs.rb:40
   sig { params(node: T.any(::RBI::Attr, ::RBI::Method)).returns(T::Array[::RBI::RBSComment]) }
   def extract_rbs_comments(node); end
 
-  # pkg:gem/rbi#lib/rbi/rewriters/translate_rbs_sigs.rb:61
+  # pkg:gem/rbi#lib/rbi/rewriters/translate_rbs_sigs.rb:67
   sig { params(node: ::RBI::Attr, comment: ::RBI::RBSComment).returns(::RBI::Sig) }
   def translate_rbs_attr_type(node, comment); end
 
-  # pkg:gem/rbi#lib/rbi/rewriters/translate_rbs_sigs.rb:53
+  # pkg:gem/rbi#lib/rbi/rewriters/translate_rbs_sigs.rb:59
   sig { params(node: ::RBI::Method, comment: ::RBI::RBSComment).returns(::RBI::Sig) }
   def translate_rbs_method_type(node, comment); end
 end
@@ -3362,34 +3615,34 @@ end
 # end
 # ~~~
 #
-# pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:622
+# pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:665
 class RBI::ScopeConflict < ::RBI::Tree
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:630
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:673
   sig { params(left: ::RBI::Scope, right: ::RBI::Scope, left_name: ::String, right_name: ::String).void }
   def initialize(left:, right:, left_name: T.unsafe(nil), right_name: T.unsafe(nil)); end
 
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:624
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:667
   sig { returns(::RBI::Scope) }
   def left; end
 
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:627
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:670
   sig { returns(::String) }
   def left_name; end
 
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:624
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:667
   def right; end
 
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:627
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:670
   def right_name; end
 end
 
 # Sends
 #
-# pkg:gem/rbi#lib/rbi/model.rb:831
+# pkg:gem/rbi#lib/rbi/model.rb:980
 class RBI::Send < ::RBI::NodeWithComments
   include ::RBI::Indexable
 
-  # pkg:gem/rbi#lib/rbi/model.rb:839
+  # pkg:gem/rbi#lib/rbi/model.rb:988
   sig do
     params(
       method: ::String,
@@ -3401,21 +3654,21 @@ class RBI::Send < ::RBI::NodeWithComments
   end
   def initialize(method, args = T.unsafe(nil), loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:847
+  # pkg:gem/rbi#lib/rbi/model.rb:996
   sig { params(arg: ::RBI::Arg).void }
   def <<(arg); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:852
+  # pkg:gem/rbi#lib/rbi/model.rb:1001
   sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
   def ==(other); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:836
+  # pkg:gem/rbi#lib/rbi/model.rb:985
   sig { returns(T::Array[::RBI::Arg]) }
   def args; end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:548
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:591
   sig { override.params(other: ::RBI::Node).returns(T::Boolean) }
   def compatible_with?(other); end
 
@@ -3425,24 +3678,25 @@ class RBI::Send < ::RBI::NodeWithComments
   sig { override.returns(T::Array[::String]) }
   def index_ids; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:833
+  # pkg:gem/rbi#lib/rbi/model.rb:982
   sig { returns(::String) }
   def method; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:857
+  # pkg:gem/rbi#lib/rbi/model.rb:1006
   sig { returns(::String) }
   def to_s; end
 end
 
 # Sorbet's sigs
 #
-# pkg:gem/rbi#lib/rbi/model.rb:906
+# pkg:gem/rbi#lib/rbi/model.rb:1055
 class RBI::Sig < ::RBI::NodeWithComments
-  # pkg:gem/rbi#lib/rbi/model.rb:964
+  # pkg:gem/rbi#lib/rbi/model.rb:1117
   sig do
     params(
       params: T.nilable(T::Array[::RBI::SigParam]),
       return_type: T.any(::RBI::Type, ::String),
+      bind_type: T.nilable(T.any(::RBI::Type, ::String)),
       is_abstract: T::Boolean,
       is_override: T::Boolean,
       is_overridable: T::Boolean,
@@ -3457,99 +3711,106 @@ class RBI::Sig < ::RBI::NodeWithComments
       block: T.nilable(T.proc.params(node: ::RBI::Sig).void)
     ).void
   end
-  def initialize(params: T.unsafe(nil), return_type: T.unsafe(nil), is_abstract: T.unsafe(nil), is_override: T.unsafe(nil), is_overridable: T.unsafe(nil), is_final: T.unsafe(nil), allow_incompatible_override: T.unsafe(nil), allow_incompatible_override_visibility: T.unsafe(nil), without_runtime: T.unsafe(nil), type_params: T.unsafe(nil), checked: T.unsafe(nil), loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
+  def initialize(params: T.unsafe(nil), return_type: T.unsafe(nil), bind_type: T.unsafe(nil), is_abstract: T.unsafe(nil), is_override: T.unsafe(nil), is_overridable: T.unsafe(nil), is_final: T.unsafe(nil), allow_incompatible_override: T.unsafe(nil), allow_incompatible_override_visibility: T.unsafe(nil), without_runtime: T.unsafe(nil), type_params: T.unsafe(nil), checked: T.unsafe(nil), loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:996
+  # pkg:gem/rbi#lib/rbi/model.rb:1151
   sig { params(param: ::RBI::SigParam).void }
   def <<(param); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1006
+  # pkg:gem/rbi#lib/rbi/model.rb:1161
   sig { params(other: ::Object).returns(T::Boolean) }
   def ==(other); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1001
+  # pkg:gem/rbi#lib/rbi/model.rb:1156
   sig { params(name: ::String, type: T.any(::RBI::Type, ::String)).void }
   def add_param(name, type); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:928
+  # pkg:gem/rbi#lib/rbi/model.rb:1080
   sig { returns(T::Boolean) }
   def allow_incompatible_override; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:928
+  # pkg:gem/rbi#lib/rbi/model.rb:1080
   def allow_incompatible_override=(_arg0); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:931
+  # pkg:gem/rbi#lib/rbi/model.rb:1083
   sig { returns(T::Boolean) }
   def allow_incompatible_override_visibility; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:931
+  # pkg:gem/rbi#lib/rbi/model.rb:1083
   def allow_incompatible_override_visibility=(_arg0); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:947
+  # pkg:gem/rbi#lib/rbi/model.rb:1065
+  sig { returns(T.nilable(T.any(::RBI::Type, ::String))) }
+  def bind_type; end
+
+  # pkg:gem/rbi#lib/rbi/model.rb:1065
+  def bind_type=(_arg0); end
+
+  # pkg:gem/rbi#lib/rbi/model.rb:1099
   sig { returns(T.nilable(::Symbol)) }
   def checked; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:947
+  # pkg:gem/rbi#lib/rbi/model.rb:1099
   def checked=(_arg0); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:916
+  # pkg:gem/rbi#lib/rbi/model.rb:1068
   sig { returns(T::Boolean) }
   def is_abstract; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:916
+  # pkg:gem/rbi#lib/rbi/model.rb:1068
   def is_abstract=(_arg0); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:925
+  # pkg:gem/rbi#lib/rbi/model.rb:1077
   sig { returns(T::Boolean) }
   def is_final; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:925
+  # pkg:gem/rbi#lib/rbi/model.rb:1077
   def is_final=(_arg0); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:922
+  # pkg:gem/rbi#lib/rbi/model.rb:1074
   sig { returns(T::Boolean) }
   def is_overridable; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:922
+  # pkg:gem/rbi#lib/rbi/model.rb:1074
   def is_overridable=(_arg0); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:919
+  # pkg:gem/rbi#lib/rbi/model.rb:1071
   sig { returns(T::Boolean) }
   def is_override; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:919
+  # pkg:gem/rbi#lib/rbi/model.rb:1071
   def is_override=(_arg0); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:908
+  # pkg:gem/rbi#lib/rbi/model.rb:1057
   sig { returns(T::Array[::RBI::SigParam]) }
   def params; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:913
+  # pkg:gem/rbi#lib/rbi/model.rb:1062
   sig { returns(T.any(::RBI::Type, ::String)) }
   def return_type; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:913
+  # pkg:gem/rbi#lib/rbi/model.rb:1062
   def return_type=(_arg0); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:937
+  # pkg:gem/rbi#lib/rbi/model.rb:1089
   sig { returns(T::Array[::String]) }
   def type_params; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:942
+  # pkg:gem/rbi#lib/rbi/model.rb:1094
   sig { returns(T::Boolean) }
   def type_params?; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:934
+  # pkg:gem/rbi#lib/rbi/model.rb:1086
   sig { returns(T::Boolean) }
   def without_runtime; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:934
+  # pkg:gem/rbi#lib/rbi/model.rb:1086
   def without_runtime=(_arg0); end
 end
 
-# pkg:gem/rbi#lib/rbi/model.rb:1015
+# pkg:gem/rbi#lib/rbi/model.rb:1171
 class RBI::SigParam < ::RBI::NodeWithComments
-  # pkg:gem/rbi#lib/rbi/model.rb:1023
+  # pkg:gem/rbi#lib/rbi/model.rb:1179
   sig do
     params(
       name: ::String,
@@ -3561,19 +3822,25 @@ class RBI::SigParam < ::RBI::NodeWithComments
   end
   def initialize(name, type, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1037
+  # pkg:gem/rbi#lib/rbi/model.rb:1199
   sig { params(other: ::Object).returns(T::Boolean) }
   def ==(other); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1032
+  # pkg:gem/rbi#lib/rbi/model.rb:1194
   sig { returns(T::Boolean) }
   def anonymous?; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1017
+  # pkg:gem/rbi#lib/rbi/model.rb:1173
   sig { returns(::String) }
   def name; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1020
+  # @override
+  #
+  # pkg:gem/rbi#lib/rbi/model.rb:1189
+  sig { override.returns(::String) }
+  def to_s; end
+
+  # pkg:gem/rbi#lib/rbi/model.rb:1176
   sig { returns(T.any(::RBI::Type, ::String)) }
   def type; end
 end
@@ -3645,9 +3912,9 @@ end
 
 # Sorbet's T::Enum
 #
-# pkg:gem/rbi#lib/rbi/model.rb:1134
+# pkg:gem/rbi#lib/rbi/model.rb:1296
 class RBI::TEnum < ::RBI::Class
-  # pkg:gem/rbi#lib/rbi/model.rb:1136
+  # pkg:gem/rbi#lib/rbi/model.rb:1298
   sig do
     params(
       name: ::String,
@@ -3659,9 +3926,9 @@ class RBI::TEnum < ::RBI::Class
   def initialize(name, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 end
 
-# pkg:gem/rbi#lib/rbi/model.rb:1142
+# pkg:gem/rbi#lib/rbi/model.rb:1304
 class RBI::TEnumBlock < ::RBI::Scope
-  # pkg:gem/rbi#lib/rbi/model.rb:1144
+  # pkg:gem/rbi#lib/rbi/model.rb:1306
   sig do
     params(
       loc: T.nilable(::RBI::Loc),
@@ -3673,7 +3940,7 @@ class RBI::TEnumBlock < ::RBI::Scope
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:1151
+  # pkg:gem/rbi#lib/rbi/model.rb:1313
   sig { override.returns(::String) }
   def fully_qualified_name; end
 
@@ -3685,16 +3952,16 @@ class RBI::TEnumBlock < ::RBI::Scope
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:1157
+  # pkg:gem/rbi#lib/rbi/model.rb:1319
   sig { override.returns(::String) }
   def to_s; end
 end
 
-# pkg:gem/rbi#lib/rbi/model.rb:1162
+# pkg:gem/rbi#lib/rbi/model.rb:1324
 class RBI::TEnumValue < ::RBI::NodeWithComments
   include ::RBI::Indexable
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1167
+  # pkg:gem/rbi#lib/rbi/model.rb:1329
   sig do
     params(
       name: ::String,
@@ -3705,7 +3972,7 @@ class RBI::TEnumValue < ::RBI::NodeWithComments
   end
   def initialize(name, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1174
+  # pkg:gem/rbi#lib/rbi/model.rb:1336
   sig { returns(::String) }
   def fully_qualified_name; end
 
@@ -3715,22 +3982,22 @@ class RBI::TEnumValue < ::RBI::NodeWithComments
   sig { override.returns(T::Array[::String]) }
   def index_ids; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1164
+  # pkg:gem/rbi#lib/rbi/model.rb:1326
   sig { returns(::String) }
   def name; end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:1180
+  # pkg:gem/rbi#lib/rbi/model.rb:1342
   sig { override.returns(::String) }
   def to_s; end
 end
 
 # Sorbet's T::Struct
 #
-# pkg:gem/rbi#lib/rbi/model.rb:1046
+# pkg:gem/rbi#lib/rbi/model.rb:1208
 class RBI::TStruct < ::RBI::Class
-  # pkg:gem/rbi#lib/rbi/model.rb:1048
+  # pkg:gem/rbi#lib/rbi/model.rb:1210
   sig do
     params(
       name: ::String,
@@ -3742,11 +4009,11 @@ class RBI::TStruct < ::RBI::Class
   def initialize(name, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 end
 
-# pkg:gem/rbi#lib/rbi/model.rb:1078
+# pkg:gem/rbi#lib/rbi/model.rb:1240
 class RBI::TStructConst < ::RBI::TStructField
   include ::RBI::Indexable
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1086
+  # pkg:gem/rbi#lib/rbi/model.rb:1248
   sig do
     params(
       name: ::String,
@@ -3761,13 +4028,13 @@ class RBI::TStructConst < ::RBI::TStructField
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:564
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:607
   sig { override.params(other: ::RBI::Node).returns(T::Boolean) }
   def compatible_with?(other); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:1093
+  # pkg:gem/rbi#lib/rbi/model.rb:1255
   sig { override.returns(T::Array[::String]) }
   def fully_qualified_names; end
 
@@ -3779,18 +4046,18 @@ class RBI::TStructConst < ::RBI::TStructField
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:1100
+  # pkg:gem/rbi#lib/rbi/model.rb:1262
   sig { override.returns(::String) }
   def to_s; end
 end
 
 # @abstract
 #
-# pkg:gem/rbi#lib/rbi/model.rb:1055
+# pkg:gem/rbi#lib/rbi/model.rb:1217
 class RBI::TStructField < ::RBI::NodeWithComments
   abstract!
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1066
+  # pkg:gem/rbi#lib/rbi/model.rb:1228
   sig do
     params(
       name: ::String,
@@ -3804,40 +4071,40 @@ class RBI::TStructField < ::RBI::NodeWithComments
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:556
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:599
   sig { override.params(other: ::RBI::Node).returns(T::Boolean) }
   def compatible_with?(other); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1063
+  # pkg:gem/rbi#lib/rbi/model.rb:1225
   sig { returns(T.nilable(::String)) }
   def default; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1063
+  # pkg:gem/rbi#lib/rbi/model.rb:1225
   def default=(_arg0); end
 
   # @abstract
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:1075
+  # pkg:gem/rbi#lib/rbi/model.rb:1237
   sig { abstract.returns(T::Array[::String]) }
   def fully_qualified_names; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1057
+  # pkg:gem/rbi#lib/rbi/model.rb:1219
   sig { returns(::String) }
   def name; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1060
+  # pkg:gem/rbi#lib/rbi/model.rb:1222
   sig { returns(T.any(::RBI::Type, ::String)) }
   def type; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1060
+  # pkg:gem/rbi#lib/rbi/model.rb:1222
   def type=(_arg0); end
 end
 
-# pkg:gem/rbi#lib/rbi/model.rb:1105
+# pkg:gem/rbi#lib/rbi/model.rb:1267
 class RBI::TStructProp < ::RBI::TStructField
   include ::RBI::Indexable
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1113
+  # pkg:gem/rbi#lib/rbi/model.rb:1275
   sig do
     params(
       name: ::String,
@@ -3852,13 +4119,13 @@ class RBI::TStructProp < ::RBI::TStructField
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:572
+  # pkg:gem/rbi#lib/rbi/rewriters/merge_trees.rb:615
   sig { override.params(other: ::RBI::Node).returns(T::Boolean) }
   def compatible_with?(other); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:1120
+  # pkg:gem/rbi#lib/rbi/model.rb:1282
   sig { override.returns(T::Array[::String]) }
   def fully_qualified_names; end
 
@@ -3870,7 +4137,7 @@ class RBI::TStructProp < ::RBI::TStructField
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:1127
+  # pkg:gem/rbi#lib/rbi/model.rb:1289
   sig { override.returns(::String) }
   def to_s; end
 end
@@ -3891,7 +4158,7 @@ class RBI::Tree < ::RBI::NodeWithComments
   sig { params(node: ::RBI::Node).void }
   def <<(node); end
 
-  # pkg:gem/rbi#lib/rbi/rewriters/add_sig_templates.rb:63
+  # pkg:gem/rbi#lib/rbi/rewriters/add_sig_templates.rb:79
   sig { params(with_todo_comment: T::Boolean).void }
   def add_sig_templates!(with_todo_comment: T.unsafe(nil)); end
 
@@ -3962,7 +4229,7 @@ class RBI::Tree < ::RBI::NodeWithComments
   sig { void }
   def sort_nodes!; end
 
-  # pkg:gem/rbi#lib/rbi/rewriters/translate_rbs_sigs.rb:82
+  # pkg:gem/rbi#lib/rbi/rewriters/translate_rbs_sigs.rb:88
   sig { void }
   def translate_rbs_sigs!; end
 end
@@ -3974,23 +4241,23 @@ end
 class RBI::Type
   abstract!
 
-  # pkg:gem/rbi#lib/rbi/type.rb:993
+  # pkg:gem/rbi#lib/rbi/type.rb:1000
   sig { void }
   def initialize; end
 
   # @abstract
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:1064
+  # pkg:gem/rbi#lib/rbi/type.rb:1071
   sig { abstract.params(other: ::BasicObject).returns(T::Boolean) }
   def ==(other); end
 
-  # pkg:gem/rbi#lib/rbi/type.rb:1067
+  # pkg:gem/rbi#lib/rbi/type.rb:1074
   sig { params(other: ::BasicObject).returns(T::Boolean) }
   def eql?(other); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:1073
+  # pkg:gem/rbi#lib/rbi/type.rb:1080
   sig { override.returns(::Integer) }
   def hash; end
 
@@ -4004,13 +4271,13 @@ class RBI::Type
   # type.nilable.nilable.to_rbi # => "::T.nilable(String)"
   # ```
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:1007
+  # pkg:gem/rbi#lib/rbi/type.rb:1014
   sig { returns(::RBI::Type) }
   def nilable; end
 
   # Returns whether the type is nilable.
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:1034
+  # pkg:gem/rbi#lib/rbi/type.rb:1041
   sig { returns(T::Boolean) }
   def nilable?; end
 
@@ -4025,7 +4292,7 @@ class RBI::Type
   # type.non_nilable.non_nilable.to_rbi # => "String"
   # ```
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:1022
+  # pkg:gem/rbi#lib/rbi/type.rb:1029
   sig { returns(::RBI::Type) }
   def non_nilable; end
 
@@ -4039,11 +4306,11 @@ class RBI::Type
   #
   # @abstract
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:1048
+  # pkg:gem/rbi#lib/rbi/type.rb:1055
   sig { abstract.returns(::RBI::Type) }
   def normalize; end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1266
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1248
   sig { returns(::String) }
   def rbs_string; end
 
@@ -4057,19 +4324,19 @@ class RBI::Type
   #
   # @abstract
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:1060
+  # pkg:gem/rbi#lib/rbi/type.rb:1067
   sig { abstract.returns(::RBI::Type) }
   def simplify; end
 
   # @abstract
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:1079
+  # pkg:gem/rbi#lib/rbi/type.rb:1086
   sig { abstract.returns(::String) }
   def to_rbi; end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:1083
+  # pkg:gem/rbi#lib/rbi/type.rb:1090
   sig { override.returns(::String) }
   def to_s; end
 
@@ -4079,7 +4346,7 @@ class RBI::Type
     # Note that this method transforms types such as `T.all(String, String)` into `String`, so
     # it may return something other than a `All`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:929
+    # pkg:gem/rbi#lib/rbi/type.rb:936
     sig { params(type1: ::RBI::Type, type2: ::RBI::Type, types: ::RBI::Type).returns(::RBI::Type) }
     def all(type1, type2, *types); end
 
@@ -4088,37 +4355,42 @@ class RBI::Type
     # Note that this method transforms types such as `T.any(String, NilClass)` into `T.nilable(String)`, so
     # it may return something other than a `Any`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:938
+    # pkg:gem/rbi#lib/rbi/type.rb:945
     sig { params(type1: ::RBI::Type, type2: ::RBI::Type, types: ::RBI::Type).returns(::RBI::Type) }
     def any(type1, type2, *types); end
 
     # Builds a type that represents `T.anything`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:854
+    # pkg:gem/rbi#lib/rbi/type.rb:861
     sig { returns(::RBI::Type::Anything) }
     def anything; end
 
     # Builds a type that represents `T.attached_class`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:860
+    # pkg:gem/rbi#lib/rbi/type.rb:867
     sig { returns(::RBI::Type::AttachedClass) }
     def attached_class; end
 
     # Builds a type that represents `T::Boolean`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:866
+    # pkg:gem/rbi#lib/rbi/type.rb:873
     sig { returns(::RBI::Type::Boolean) }
     def boolean; end
 
     # Builds a type that represents the singleton class of another type like `T.class_of(Foo)`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:910
-    sig { params(type: ::RBI::Type::Simple, type_parameter: T.nilable(::RBI::Type)).returns(::RBI::Type::ClassOf) }
-    def class_of(type, type_parameter = T.unsafe(nil)); end
+    # pkg:gem/rbi#lib/rbi/type.rb:917
+    sig do
+      params(
+        type: ::RBI::Type::Simple,
+        type_parameters: T.any(::RBI::Type, T::Array[::RBI::Type])
+      ).returns(::RBI::Type::ClassOf)
+    end
+    def class_of(type, *type_parameters); end
 
     # Builds a type that represents a generic type like `T::Array[String]` or `T::Hash[Symbol, Integer]`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:946
+    # pkg:gem/rbi#lib/rbi/type.rb:953
     sig { params(name: ::String, params: T.any(::RBI::Type, T::Array[::RBI::Type])).returns(::RBI::Type::Generic) }
     def generic(name, *params); end
 
@@ -4127,13 +4399,13 @@ class RBI::Type
     # Note that this method transforms types such as `T.nilable(T.untyped)` into `T.untyped`, so
     # it may return something other than a `RBI::Type::Nilable`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:919
+    # pkg:gem/rbi#lib/rbi/type.rb:926
     sig { params(type: ::RBI::Type).returns(::RBI::Type) }
     def nilable(type); end
 
     # Builds a type that represents `T.noreturn`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:872
+    # pkg:gem/rbi#lib/rbi/type.rb:879
     sig { returns(::RBI::Type::NoReturn) }
     def noreturn; end
 
@@ -4147,19 +4419,19 @@ class RBI::Type
 
     # Builds a type that represents a proc type like `T.proc.void`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:980
+    # pkg:gem/rbi#lib/rbi/type.rb:987
     sig { returns(::RBI::Type::Proc) }
     def proc; end
 
     # Builds a type that represents `T.self_type`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:878
+    # pkg:gem/rbi#lib/rbi/type.rb:885
     sig { returns(::RBI::Type::SelfType) }
     def self_type; end
 
     # Builds a type that represents a shape type like `{name: String, age: Integer}`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:972
+    # pkg:gem/rbi#lib/rbi/type.rb:979
     sig { params(types: T::Hash[T.any(::String, ::Symbol), ::RBI::Type]).returns(::RBI::Type::Shape) }
     def shape(types = T.unsafe(nil)); end
 
@@ -4167,63 +4439,63 @@ class RBI::Type
     #
     # It raises a `NameError` if the name is not a valid Ruby class identifier.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:843
+    # pkg:gem/rbi#lib/rbi/type.rb:850
     sig { params(name: ::String).returns(::RBI::Type::Simple) }
     def simple(name); end
 
     # Builds a type that represents the class of another type like `T::Class[Foo]`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:898
+    # pkg:gem/rbi#lib/rbi/type.rb:905
     sig { params(type: ::RBI::Type).returns(::RBI::Type::Class) }
     def t_class(type); end
 
     # Builds a type that represents the module of another type like `T::Module[Foo]`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:904
+    # pkg:gem/rbi#lib/rbi/type.rb:911
     sig { params(type: ::RBI::Type).returns(::RBI::Type::Module) }
     def t_module(type); end
 
     # Builds a type that represents a tuple type like `[String, Integer]`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:966
+    # pkg:gem/rbi#lib/rbi/type.rb:973
     sig { params(types: T.any(::RBI::Type, T::Array[::RBI::Type])).returns(::RBI::Type::Tuple) }
     def tuple(*types); end
 
     # Builds a type that represents a type alias like `MyTypeAlias`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:958
+    # pkg:gem/rbi#lib/rbi/type.rb:965
     sig { params(name: ::String, aliased_type: ::RBI::Type).returns(::RBI::Type::TypeAlias) }
     def type_alias(name, aliased_type); end
 
     # Builds a type that represents a type parameter like `T.type_parameter(:U)`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:952
+    # pkg:gem/rbi#lib/rbi/type.rb:959
     sig { params(name: ::Symbol).returns(::RBI::Type::TypeParameter) }
     def type_parameter(name); end
 
     # Builds a type that represents `T.untyped`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:884
+    # pkg:gem/rbi#lib/rbi/type.rb:891
     sig { returns(::RBI::Type::Untyped) }
     def untyped; end
 
     # Builds a type that represents `void`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:890
+    # pkg:gem/rbi#lib/rbi/type.rb:897
     sig { returns(::RBI::Type::Void) }
     def void; end
 
     private
 
-    # pkg:gem/rbi#lib/rbi/type_parser.rb:322
+    # pkg:gem/rbi#lib/rbi/type_parser.rb:320
     sig { params(node: ::Prism::CallNode).returns(T::Array[::Prism::Node]) }
     def call_chain(node); end
 
-    # pkg:gem/rbi#lib/rbi/type_parser.rb:309
+    # pkg:gem/rbi#lib/rbi/type_parser.rb:307
     sig { params(node: ::Prism::CallNode, count: ::Integer).returns(T::Array[::Prism::Node]) }
     def check_arguments_at_least!(node, count); end
 
-    # pkg:gem/rbi#lib/rbi/type_parser.rb:294
+    # pkg:gem/rbi#lib/rbi/type_parser.rb:292
     sig { params(node: ::Prism::CallNode, count: ::Integer).returns(T::Array[::Prism::Node]) }
     def check_arguments_exactly!(node, count); end
 
@@ -4239,47 +4511,47 @@ class RBI::Type
     sig { params(node: T.any(::Prism::ConstantPathWriteNode, ::Prism::ConstantWriteNode)).returns(::RBI::Type) }
     def parse_constant_assignment(node); end
 
-    # pkg:gem/rbi#lib/rbi/type_parser.rb:244
+    # pkg:gem/rbi#lib/rbi/type_parser.rb:242
     sig { params(node: ::Prism::CallNode).returns(::RBI::Type) }
     def parse_proc(node); end
 
-    # pkg:gem/rbi#lib/rbi/type_parser.rb:223
+    # pkg:gem/rbi#lib/rbi/type_parser.rb:221
     sig { params(node: T.any(::Prism::HashNode, ::Prism::KeywordHashNode)).returns(::RBI::Type) }
     def parse_shape(node); end
 
-    # pkg:gem/rbi#lib/rbi/type_parser.rb:218
+    # pkg:gem/rbi#lib/rbi/type_parser.rb:216
     sig { params(node: ::Prism::ArrayNode).returns(::RBI::Type) }
     def parse_tuple(node); end
 
-    # pkg:gem/rbi#lib/rbi/type_parser.rb:335
+    # pkg:gem/rbi#lib/rbi/type_parser.rb:333
     sig { params(node: T.nilable(::Prism::Node)).returns(T::Boolean) }
     def t?(node); end
 
-    # pkg:gem/rbi#lib/rbi/type_parser.rb:354
+    # pkg:gem/rbi#lib/rbi/type_parser.rb:352
     sig { params(node: T.nilable(::Prism::Node)).returns(T::Boolean) }
     def t_boolean?(node); end
 
-    # pkg:gem/rbi#lib/rbi/type_parser.rb:361
+    # pkg:gem/rbi#lib/rbi/type_parser.rb:359
     sig { params(node: ::Prism::ConstantPathNode).returns(T::Boolean) }
     def t_class?(node); end
 
-    # pkg:gem/rbi#lib/rbi/type_parser.rb:371
+    # pkg:gem/rbi#lib/rbi/type_parser.rb:369
     sig { params(node: T.nilable(::Prism::Node)).returns(T::Boolean) }
     def t_class_of?(node); end
 
-    # pkg:gem/rbi#lib/rbi/type_parser.rb:366
+    # pkg:gem/rbi#lib/rbi/type_parser.rb:364
     sig { params(node: ::Prism::ConstantPathNode).returns(T::Boolean) }
     def t_module?(node); end
 
-    # pkg:gem/rbi#lib/rbi/type_parser.rb:378
+    # pkg:gem/rbi#lib/rbi/type_parser.rb:376
     sig { params(node: ::Prism::CallNode).returns(T::Boolean) }
     def t_proc?(node); end
 
-    # pkg:gem/rbi#lib/rbi/type_parser.rb:347
+    # pkg:gem/rbi#lib/rbi/type_parser.rb:345
     sig { params(node: T.nilable(::Prism::Node)).returns(T::Boolean) }
     def t_type_alias?(node); end
 
-    # pkg:gem/rbi#lib/rbi/type.rb:987
+    # pkg:gem/rbi#lib/rbi/type.rb:994
     sig { params(name: ::String).returns(T::Boolean) }
     def valid_identifier?(name); end
   end
@@ -4464,8 +4736,8 @@ end
 # pkg:gem/rbi#lib/rbi/type.rb:314
 class RBI::Type::ClassOf < ::RBI::Type
   # pkg:gem/rbi#lib/rbi/type.rb:322
-  sig { params(type: ::RBI::Type::Simple, type_parameter: T.nilable(::RBI::Type)).void }
-  def initialize(type, type_parameter = T.unsafe(nil)); end
+  sig { params(type: ::RBI::Type::Simple, type_parameters: ::RBI::Type).void }
+  def initialize(type, *type_parameters); end
 
   # @override
   #
@@ -4496,8 +4768,8 @@ class RBI::Type::ClassOf < ::RBI::Type
   def type; end
 
   # pkg:gem/rbi#lib/rbi/type.rb:319
-  sig { returns(T.nilable(::RBI::Type)) }
-  def type_parameter; end
+  sig { returns(T::Array[::RBI::Type]) }
+  def type_parameters; end
 end
 
 # A type that is composed of multiple types like `T.all(String, Integer)`.
@@ -4671,61 +4943,61 @@ end
 
 # A proc type like `T.proc.void`.
 #
-# pkg:gem/rbi#lib/rbi/type.rb:743
+# pkg:gem/rbi#lib/rbi/type.rb:750
 class RBI::Type::Proc < ::RBI::Type
-  # pkg:gem/rbi#lib/rbi/type.rb:754
+  # pkg:gem/rbi#lib/rbi/type.rb:761
   sig { void }
   def initialize; end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:763
+  # pkg:gem/rbi#lib/rbi/type.rb:770
   sig { override.params(other: ::BasicObject).returns(T::Boolean) }
   def ==(other); end
 
-  # pkg:gem/rbi#lib/rbi/type.rb:791
+  # pkg:gem/rbi#lib/rbi/type.rb:798
   sig { params(type: T.untyped).returns(T.self_type) }
   def bind(type); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:823
+  # pkg:gem/rbi#lib/rbi/type.rb:830
   sig { override.returns(::RBI::Type) }
   def normalize; end
 
-  # pkg:gem/rbi#lib/rbi/type.rb:773
+  # pkg:gem/rbi#lib/rbi/type.rb:780
   sig { params(params: ::RBI::Type).returns(T.self_type) }
   def params(**params); end
 
-  # pkg:gem/rbi#lib/rbi/type.rb:751
+  # pkg:gem/rbi#lib/rbi/type.rb:758
   sig { returns(T.nilable(::RBI::Type)) }
   def proc_bind; end
 
-  # pkg:gem/rbi#lib/rbi/type.rb:745
+  # pkg:gem/rbi#lib/rbi/type.rb:752
   sig { returns(T::Hash[::Symbol, ::RBI::Type]) }
   def proc_params; end
 
-  # pkg:gem/rbi#lib/rbi/type.rb:748
+  # pkg:gem/rbi#lib/rbi/type.rb:755
   sig { returns(::RBI::Type) }
   def proc_returns; end
 
-  # pkg:gem/rbi#lib/rbi/type.rb:779
+  # pkg:gem/rbi#lib/rbi/type.rb:786
   sig { params(type: T.untyped).returns(T.self_type) }
   def returns(type); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:829
+  # pkg:gem/rbi#lib/rbi/type.rb:836
   sig { override.returns(::RBI::Type) }
   def simplify; end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:798
+  # pkg:gem/rbi#lib/rbi/type.rb:805
   sig { override.returns(::String) }
   def to_rbi; end
 
-  # pkg:gem/rbi#lib/rbi/type.rb:785
+  # pkg:gem/rbi#lib/rbi/type.rb:792
   sig { returns(T.self_type) }
   def void; end
 end
@@ -4775,13 +5047,13 @@ class RBI::Type::Shape < ::RBI::Type
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:729
+  # pkg:gem/rbi#lib/rbi/type.rb:736
   sig { override.returns(::RBI::Type) }
   def normalize; end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:735
+  # pkg:gem/rbi#lib/rbi/type.rb:742
   sig { override.returns(::RBI::Type) }
   def simplify; end
 
@@ -5096,11 +5368,11 @@ class RBI::Type::Void < ::RBI::Type
   def to_rbi; end
 end
 
-# pkg:gem/rbi#lib/rbi/model.rb:1205
+# pkg:gem/rbi#lib/rbi/model.rb:1367
 class RBI::TypeMember < ::RBI::NodeWithComments
   include ::RBI::Indexable
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1210
+  # pkg:gem/rbi#lib/rbi/model.rb:1372
   sig do
     params(
       name: ::String,
@@ -5112,7 +5384,7 @@ class RBI::TypeMember < ::RBI::NodeWithComments
   end
   def initialize(name, value, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1218
+  # pkg:gem/rbi#lib/rbi/model.rb:1380
   sig { returns(::String) }
   def fully_qualified_name; end
 
@@ -5122,113 +5394,113 @@ class RBI::TypeMember < ::RBI::NodeWithComments
   sig { override.returns(T::Array[::String]) }
   def index_ids; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1207
+  # pkg:gem/rbi#lib/rbi/model.rb:1369
   sig { returns(::String) }
   def name; end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/model.rb:1226
+  # pkg:gem/rbi#lib/rbi/model.rb:1388
   sig { override.returns(::String) }
   def to_s; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:1207
+  # pkg:gem/rbi#lib/rbi/model.rb:1369
   def value; end
 end
 
-# pkg:gem/rbi#lib/rbi/rbs_printer.rb:984
+# pkg:gem/rbi#lib/rbi/rbs_printer.rb:963
 class RBI::TypePrinter
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:989
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:968
   sig { params(max_line_length: T.nilable(::Integer)).void }
   def initialize(max_line_length: T.unsafe(nil)); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:986
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:965
   sig { returns(::String) }
   def string; end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:995
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:974
   sig { params(node: ::RBI::Type).void }
   def visit(node); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1117
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1099
   sig { params(type: ::RBI::Type::All).void }
   def visit_all(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1127
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1109
   sig { params(type: ::RBI::Type::Any).void }
   def visit_any(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1062
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1041
   sig { params(type: ::RBI::Type::Anything).void }
   def visit_anything(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1087
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1066
   sig { params(type: ::RBI::Type::AttachedClass).void }
   def visit_attached_class(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1046
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1025
   sig { params(type: ::RBI::Type::Boolean).void }
   def visit_boolean(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1194
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1176
   sig { params(type: ::RBI::Type::Class).void }
   def visit_class(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1105
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1084
   sig { params(type: ::RBI::Type::ClassOf).void }
   def visit_class_of(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1051
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1030
   sig { params(type: ::RBI::Type::Generic).void }
   def visit_generic(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1201
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1183
   sig { params(type: ::RBI::Type::Module).void }
   def visit_module(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1092
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1071
   sig { params(type: ::RBI::Type::Nilable).void }
   def visit_nilable(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1072
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1051
   sig { params(type: ::RBI::Type::NoReturn).void }
   def visit_no_return(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1167
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1149
   sig { params(type: ::RBI::Type::Proc).void }
   def visit_proc(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1082
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1061
   sig { params(type: ::RBI::Type::SelfType).void }
   def visit_self_type(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1147
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1129
   sig { params(type: ::RBI::Type::Shape).void }
   def visit_shape(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1041
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1020
   sig { params(type: ::RBI::Type::Simple).void }
   def visit_simple(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1137
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1119
   sig { params(type: ::RBI::Type::Tuple).void }
   def visit_tuple(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1189
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1171
   sig { params(type: ::RBI::Type::TypeParameter).void }
   def visit_type_parameter(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1077
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1056
   sig { params(type: ::RBI::Type::Untyped).void }
   def visit_untyped(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1067
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1046
   sig { params(type: ::RBI::Type::Void).void }
   def visit_void(type); end
 
   private
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1210
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1192
   sig { params(type_name: ::String).returns(::String) }
   def translate_t_type(type_name); end
 end
@@ -5264,31 +5536,31 @@ RBI::VERSION = T.let(T.unsafe(nil), String)
 
 # @abstract
 #
-# pkg:gem/rbi#lib/rbi/model.rb:769
+# pkg:gem/rbi#lib/rbi/model.rb:918
 class RBI::Visibility < ::RBI::NodeWithComments
   abstract!
 
-  # pkg:gem/rbi#lib/rbi/model.rb:774
+  # pkg:gem/rbi#lib/rbi/model.rb:923
   sig { params(visibility: ::Symbol, loc: T.nilable(::RBI::Loc), comments: T.nilable(T::Array[::RBI::Comment])).void }
   def initialize(visibility, loc: T.unsafe(nil), comments: T.unsafe(nil)); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:780
+  # pkg:gem/rbi#lib/rbi/model.rb:929
   sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
   def ==(other); end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:797
+  # pkg:gem/rbi#lib/rbi/model.rb:946
   sig { returns(T::Boolean) }
   def private?; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:792
+  # pkg:gem/rbi#lib/rbi/model.rb:941
   sig { returns(T::Boolean) }
   def protected?; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:787
+  # pkg:gem/rbi#lib/rbi/model.rb:936
   sig { returns(T::Boolean) }
   def public?; end
 
-  # pkg:gem/rbi#lib/rbi/model.rb:771
+  # pkg:gem/rbi#lib/rbi/model.rb:920
   sig { returns(::Symbol) }
   def visibility; end
 end
@@ -5314,189 +5586,193 @@ class RBI::Visitor
   sig { params(node: T.nilable(::RBI::Node)).void }
   def visit(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:108
+  # pkg:gem/rbi#lib/rbi/visitor.rb:110
   sig { params(nodes: T::Array[::RBI::Node]).void }
   def visit_all(nodes); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:113
+  # pkg:gem/rbi#lib/rbi/visitor.rb:115
   sig { params(file: ::RBI::File).void }
   def visit_file(file); end
 
   private
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:198
+  # pkg:gem/rbi#lib/rbi/visitor.rb:203
   sig { params(node: ::RBI::Arg).void }
   def visit_arg(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:147
+  # pkg:gem/rbi#lib/rbi/visitor.rb:149
   sig { params(node: ::RBI::AttrAccessor).void }
   def visit_attr_accessor(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:150
+  # pkg:gem/rbi#lib/rbi/visitor.rb:152
   sig { params(node: ::RBI::AttrReader).void }
   def visit_attr_reader(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:153
+  # pkg:gem/rbi#lib/rbi/visitor.rb:155
   sig { params(node: ::RBI::AttrWriter).void }
   def visit_attr_writer(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:126
+  # pkg:gem/rbi#lib/rbi/visitor.rb:128
   sig { params(node: ::RBI::BlankLine).void }
   def visit_blank_line(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:177
+  # pkg:gem/rbi#lib/rbi/visitor.rb:182
   sig { params(node: ::RBI::BlockParam).void }
   def visit_block_param(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:132
+  # pkg:gem/rbi#lib/rbi/visitor.rb:134
   sig { params(node: ::RBI::Class).void }
   def visit_class(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:120
+  # pkg:gem/rbi#lib/rbi/visitor.rb:122
   sig { params(node: ::RBI::Comment).void }
   def visit_comment(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:246
+  # pkg:gem/rbi#lib/rbi/visitor.rb:251
   sig { params(node: ::RBI::ConflictTree).void }
   def visit_conflict_tree(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:144
+  # pkg:gem/rbi#lib/rbi/visitor.rb:146
   sig { params(node: ::RBI::Const).void }
   def visit_const(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:183
+  # pkg:gem/rbi#lib/rbi/visitor.rb:188
   sig { params(node: ::RBI::Extend).void }
   def visit_extend(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:240
+  # pkg:gem/rbi#lib/rbi/visitor.rb:245
   sig { params(node: ::RBI::Group).void }
   def visit_group(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:228
+  # pkg:gem/rbi#lib/rbi/visitor.rb:233
   sig { params(node: ::RBI::Helper).void }
   def visit_helper(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:180
+  # pkg:gem/rbi#lib/rbi/visitor.rb:185
   sig { params(node: ::RBI::Include).void }
   def visit_include(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:201
+  # pkg:gem/rbi#lib/rbi/visitor.rb:206
   sig { params(node: ::RBI::KwArg).void }
   def visit_kw_arg(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:171
+  # pkg:gem/rbi#lib/rbi/visitor.rb:173
   sig { params(node: ::RBI::KwOptParam).void }
   def visit_kw_opt_param(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:168
+  # pkg:gem/rbi#lib/rbi/visitor.rb:170
   sig { params(node: ::RBI::KwParam).void }
   def visit_kw_param(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:174
+  # pkg:gem/rbi#lib/rbi/visitor.rb:176
   sig { params(node: ::RBI::KwRestParam).void }
   def visit_kw_rest_param(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:156
+  # pkg:gem/rbi#lib/rbi/visitor.rb:158
   sig { params(node: ::RBI::Method).void }
   def visit_method(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:234
+  # pkg:gem/rbi#lib/rbi/visitor.rb:239
   sig { params(node: ::RBI::MixesInClassMethods).void }
   def visit_mixes_in_class_methods(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:129
+  # pkg:gem/rbi#lib/rbi/visitor.rb:131
   sig { params(node: ::RBI::Module).void }
   def visit_module(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:162
+  # pkg:gem/rbi#lib/rbi/visitor.rb:179
+  sig { params(node: ::RBI::NoKwParam).void }
+  def visit_no_kw_param(node); end
+
+  # pkg:gem/rbi#lib/rbi/visitor.rb:164
   sig { params(node: ::RBI::OptParam).void }
   def visit_opt_param(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:192
+  # pkg:gem/rbi#lib/rbi/visitor.rb:197
   sig { params(node: ::RBI::Private).void }
   def visit_private(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:189
+  # pkg:gem/rbi#lib/rbi/visitor.rb:194
   sig { params(node: ::RBI::Protected).void }
   def visit_protected(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:186
+  # pkg:gem/rbi#lib/rbi/visitor.rb:191
   sig { params(node: ::RBI::Public).void }
   def visit_public(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:123
+  # pkg:gem/rbi#lib/rbi/visitor.rb:125
   sig { params(node: ::RBI::RBSComment).void }
   def visit_rbs_comment(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:159
+  # pkg:gem/rbi#lib/rbi/visitor.rb:161
   sig { params(node: ::RBI::ReqParam).void }
   def visit_req_param(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:237
+  # pkg:gem/rbi#lib/rbi/visitor.rb:242
   sig { params(node: ::RBI::RequiresAncestor).void }
   def visit_requires_ancestor(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:165
+  # pkg:gem/rbi#lib/rbi/visitor.rb:167
   sig { params(node: ::RBI::RestParam).void }
   def visit_rest_param(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:249
+  # pkg:gem/rbi#lib/rbi/visitor.rb:254
   sig { params(node: ::RBI::ScopeConflict).void }
   def visit_scope_conflict(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:195
+  # pkg:gem/rbi#lib/rbi/visitor.rb:200
   sig { params(node: ::RBI::Send).void }
   def visit_send(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:204
+  # pkg:gem/rbi#lib/rbi/visitor.rb:209
   sig { params(node: ::RBI::Sig).void }
   def visit_sig(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:207
+  # pkg:gem/rbi#lib/rbi/visitor.rb:212
   sig { params(node: ::RBI::SigParam).void }
   def visit_sig_param(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:135
+  # pkg:gem/rbi#lib/rbi/visitor.rb:137
   sig { params(node: ::RBI::SingletonClass).void }
   def visit_singleton_class(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:138
+  # pkg:gem/rbi#lib/rbi/visitor.rb:140
   sig { params(node: ::RBI::Struct).void }
   def visit_struct(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:219
+  # pkg:gem/rbi#lib/rbi/visitor.rb:224
   sig { params(node: ::RBI::TEnum).void }
   def visit_tenum(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:222
+  # pkg:gem/rbi#lib/rbi/visitor.rb:227
   sig { params(node: ::RBI::TEnumBlock).void }
   def visit_tenum_block(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:225
+  # pkg:gem/rbi#lib/rbi/visitor.rb:230
   sig { params(node: ::RBI::TEnumValue).void }
   def visit_tenum_value(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:141
+  # pkg:gem/rbi#lib/rbi/visitor.rb:143
   sig { params(node: ::RBI::Tree).void }
   def visit_tree(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:210
+  # pkg:gem/rbi#lib/rbi/visitor.rb:215
   sig { params(node: ::RBI::TStruct).void }
   def visit_tstruct(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:213
+  # pkg:gem/rbi#lib/rbi/visitor.rb:218
   sig { params(node: ::RBI::TStructConst).void }
   def visit_tstruct_const(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:216
+  # pkg:gem/rbi#lib/rbi/visitor.rb:221
   sig { params(node: ::RBI::TStructProp).void }
   def visit_tstruct_prop(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:231
+  # pkg:gem/rbi#lib/rbi/visitor.rb:236
   sig { params(node: ::RBI::TypeMember).void }
   def visit_type_member(node); end
 
-  # pkg:gem/rbi#lib/rbi/visitor.rb:243
+  # pkg:gem/rbi#lib/rbi/visitor.rb:248
   sig { params(node: ::RBI::VisibilityGroup).void }
   def visit_visibility_group(node); end
 end

--- a/sorbet/rbi/gems/spoom@1.8.7.rbi
+++ b/sorbet/rbi/gems/spoom@1.8.7.rbi
@@ -233,23 +233,24 @@ class Spoom::Cli::Srb::Assertions < ::Thor
   def translate(*paths); end
 end
 
-# pkg:gem/spoom#lib/spoom/cli/srb/bump.rb:10
+# pkg:gem/spoom#lib/spoom/cli/srb/bump.rb:12
 class Spoom::Cli::Srb::Bump < ::Thor
   include ::Spoom::Colorize
   include ::Spoom::Cli::Helper
 
-  # pkg:gem/spoom#lib/spoom/cli/srb/bump.rb:49
+  # pkg:gem/spoom#lib/spoom/cli/srb/bump.rb:51
   sig { params(directory: ::String).void }
   def bump(directory = T.unsafe(nil)); end
+
+  # pkg:gem/spoom#lib/spoom/cli/srb/bump.rb:205
+  sig { params(context: ::Spoom::Context, files: T::Array[::String], strictness: ::String).returns(::Tempfile) }
+  def create_typed_override_file(context, files, strictness); end
 
   # pkg:gem/spoom#lib/spoom/cli/srb.rb:20
   def help(command = T.unsafe(nil), subcommand = T.unsafe(nil)); end
 
-  # pkg:gem/spoom#lib/spoom/cli/srb/bump.rb:170
+  # pkg:gem/spoom#lib/spoom/cli/srb/bump.rb:182
   def print_changes(files, command:, from: T.unsafe(nil), to: T.unsafe(nil), dry: T.unsafe(nil), path: T.unsafe(nil)); end
-
-  # pkg:gem/spoom#lib/spoom/cli/srb/bump.rb:192
-  def undo_changes(files, from_strictness); end
 end
 
 # pkg:gem/spoom#lib/spoom/cli/srb/coverage.rb:10
@@ -390,22 +391,22 @@ class Spoom::Cli::Srb::Sigs < ::Thor
   include ::Spoom::Colorize
   include ::Spoom::Cli::Helper
 
-  # pkg:gem/spoom#lib/spoom/cli/srb/sigs.rb:229
+  # pkg:gem/spoom#lib/spoom/cli/srb/sigs.rb:239
   def exec(context, command); end
 
-  # pkg:gem/spoom#lib/spoom/cli/srb/sigs.rb:95
+  # pkg:gem/spoom#lib/spoom/cli/srb/sigs.rb:105
   def export(output_path = T.unsafe(nil)); end
 
   # pkg:gem/spoom#lib/spoom/cli/srb.rb:32
   def help(command = T.unsafe(nil), subcommand = T.unsafe(nil)); end
 
-  # pkg:gem/spoom#lib/spoom/cli/srb/sigs.rb:76
+  # pkg:gem/spoom#lib/spoom/cli/srb/sigs.rb:86
   def strip(*paths); end
 
-  # pkg:gem/spoom#lib/spoom/cli/srb/sigs.rb:204
+  # pkg:gem/spoom#lib/spoom/cli/srb/sigs.rb:214
   def transform_files(files, &block); end
 
-  # pkg:gem/spoom#lib/spoom/cli/srb/sigs.rb:25
+  # pkg:gem/spoom#lib/spoom/cli/srb/sigs.rb:33
   def translate(*paths); end
 end
 
@@ -414,10 +415,10 @@ class Spoom::Cli::Srb::Tc < ::Thor
   include ::Spoom::Colorize
   include ::Spoom::Cli::Helper
 
-  # pkg:gem/spoom#lib/spoom/cli/srb/tc.rb:147
+  # pkg:gem/spoom#lib/spoom/cli/srb/tc.rb:151
   def colorize_message(message); end
 
-  # pkg:gem/spoom#lib/spoom/cli/srb/tc.rb:138
+  # pkg:gem/spoom#lib/spoom/cli/srb/tc.rb:142
   def format_error(error, format); end
 
   # pkg:gem/spoom#lib/spoom/cli/srb.rb:35
@@ -1679,37 +1680,42 @@ class Spoom::Deadcode::ERB < ::Erubi::Engine
   sig { params(input: T.untyped, properties: T.untyped).void }
   def initialize(input, properties = T.unsafe(nil)); end
 
+  # pkg:gem/spoom#lib/spoom/deadcode/erb.rb:44
+  sig { returns(::String) }
+  def wrapped_src; end
+
   private
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/deadcode/erb.rb:84
+  # pkg:gem/spoom#lib/spoom/deadcode/erb.rb:95
   sig { override.params(code: T.untyped).void }
   def add_code(code); end
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/deadcode/erb.rb:66
+  # pkg:gem/spoom#lib/spoom/deadcode/erb.rb:75
   sig { override.params(indicator: T.untyped, code: T.untyped).void }
   def add_expression(indicator, code); end
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/deadcode/erb.rb:91
+  # pkg:gem/spoom#lib/spoom/deadcode/erb.rb:102
+  sig { override.params(_: T.untyped).void }
   def add_postamble(_); end
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/deadcode/erb.rb:47
+  # pkg:gem/spoom#lib/spoom/deadcode/erb.rb:56
   sig { override.params(text: T.untyped).void }
   def add_text(text); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/erb.rb:97
+  # pkg:gem/spoom#lib/spoom/deadcode/erb.rb:108
   sig { params(src: T.untyped).void }
   def flush_newline_if_pending(src); end
 end
 
-# pkg:gem/spoom#lib/spoom/deadcode/erb.rb:62
+# pkg:gem/spoom#lib/spoom/deadcode/erb.rb:71
 Spoom::Deadcode::ERB::BLOCK_EXPR = T.let(T.unsafe(nil), Regexp)
 
 # pkg:gem/spoom#lib/spoom/deadcode/index.rb:6
@@ -1718,19 +1724,19 @@ class Spoom::Deadcode::Index
   sig { params(model: ::Spoom::Model).void }
   def initialize(model); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/index.rb:215
+  # pkg:gem/spoom#lib/spoom/deadcode/index.rb:220
   sig { returns(T::Array[::Spoom::Deadcode::Definition]) }
   def all_definitions; end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/index.rb:220
+  # pkg:gem/spoom#lib/spoom/deadcode/index.rb:225
   sig { returns(T::Array[::Spoom::Model::Reference]) }
   def all_references; end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/index.rb:95
+  # pkg:gem/spoom#lib/spoom/deadcode/index.rb:100
   sig { params(plugins: T::Array[::Spoom::Deadcode::Plugins::Base]).void }
   def apply_plugins!(plugins); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/index.rb:75
+  # pkg:gem/spoom#lib/spoom/deadcode/index.rb:80
   sig { params(definition: ::Spoom::Deadcode::Definition).void }
   def define(definition); end
 
@@ -1738,7 +1744,7 @@ class Spoom::Deadcode::Index
   sig { returns(T::Hash[::String, T::Array[::Spoom::Deadcode::Definition]]) }
   def definitions; end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/index.rb:210
+  # pkg:gem/spoom#lib/spoom/deadcode/index.rb:215
   sig { params(name: ::String).returns(T::Array[::Spoom::Deadcode::Definition]) }
   def definitions_for_name(name); end
 
@@ -1746,11 +1752,11 @@ class Spoom::Deadcode::Index
   #
   # To be called once all the files have been indexed and all the definitions and references discovered.
   #
-  # pkg:gem/spoom#lib/spoom/deadcode/index.rb:118
+  # pkg:gem/spoom#lib/spoom/deadcode/index.rb:123
   sig { void }
   def finalize!; end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/index.rb:90
+  # pkg:gem/spoom#lib/spoom/deadcode/index.rb:95
   sig { params(symbol_def: ::Spoom::Model::SymbolDef).void }
   def ignore(symbol_def); end
 
@@ -1770,11 +1776,11 @@ class Spoom::Deadcode::Index
   sig { returns(::Spoom::Model) }
   def model; end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/index.rb:80
+  # pkg:gem/spoom#lib/spoom/deadcode/index.rb:85
   sig { params(name: ::String, location: ::Spoom::Location).void }
   def reference_constant(name, location); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/index.rb:85
+  # pkg:gem/spoom#lib/spoom/deadcode/index.rb:90
   sig { params(name: ::String, location: ::Spoom::Location).void }
   def reference_method(name, location); end
 
@@ -1878,7 +1884,16 @@ class Spoom::Deadcode::Plugins::ActiveModel < ::Spoom::Deadcode::Plugins::Base
   # pkg:gem/spoom#lib/spoom/deadcode/plugins/active_model.rb:13
   sig { override.params(send: ::Spoom::Deadcode::Send).void }
   def on_send(send); end
+
+  private
+
+  # pkg:gem/spoom#lib/spoom/deadcode/plugins/active_model.rb:68
+  sig { params(hash_node: ::Prism::HashNode, location: ::Spoom::Location).void }
+  def reference_nested_symbol_options(hash_node, location); end
 end
+
+# pkg:gem/spoom#lib/spoom/deadcode/plugins/active_model.rb:51
+Spoom::Deadcode::Plugins::ActiveModel::NESTED_METHOD_REFERENCE_KEYS = T.let(T.unsafe(nil), Array)
 
 # pkg:gem/spoom#lib/spoom/deadcode/plugins/active_record.rb:7
 class Spoom::Deadcode::Plugins::ActiveRecord < ::Spoom::Deadcode::Plugins::Base
@@ -2053,57 +2068,58 @@ class Spoom::Deadcode::Plugins::Base
   # class MyPlugin < Spoom::Deadcode::Plugins::Base
   #   def on_send(send)
   #     return unless send.name == "dsl_method"
-  #     return if send.args.empty?
   #
-  #     method_name = send.args.first.slice.delete_prefix(":")
-  #     @index.reference_method(method_name, send.node, send.loc)
+  #     arg = send.args.first
+  #     return unless arg.is_a?(Prism::SymbolNode)
+  #
+  #     @index.reference_method(arg.unescaped, send.node, send.loc)
   #   end
   # end
   # ~~~
   #
-  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:278
+  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:279
   sig { params(send: ::Spoom::Deadcode::Send).void }
   def on_send(send); end
 
   private
 
-  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:346
+  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:347
   sig { params(name: ::String).returns(::String) }
   def camelize(name); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:295
+  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:296
   sig { params(name: T.nilable(::String)).returns(T::Boolean) }
   def ignored_class_name?(name); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:314
+  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:315
   sig { params(name: ::String).returns(T::Boolean) }
   def ignored_constant_name?(name); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:319
+  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:320
   sig { params(name: ::String).returns(T::Boolean) }
   def ignored_method_name?(name); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:324
+  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:325
   sig { params(name: ::String).returns(T::Boolean) }
   def ignored_module_name?(name); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:329
+  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:330
   sig { params(name: ::String, names_variable: ::Symbol, patterns_variable: ::Symbol).returns(T::Boolean) }
   def ignored_name?(name, names_variable, patterns_variable); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:302
+  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:303
   sig { params(definition: ::Spoom::Model::Class).returns(T::Boolean) }
   def ignored_subclass?(definition); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:334
+  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:335
   sig { params(const: ::Symbol).returns(T::Set[::String]) }
   def names(const); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:339
+  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:340
   sig { params(const: ::Symbol).returns(T::Array[::Regexp]) }
   def patterns(const); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:287
+  # pkg:gem/spoom#lib/spoom/deadcode/plugins/base.rb:288
   sig { params(definition: ::Spoom::Model::Namespace, superclass_name: ::String).returns(T::Boolean) }
   def subclass_of?(definition, superclass_name); end
 
@@ -2216,10 +2232,30 @@ end
 class Spoom::Deadcode::Plugins::GraphQL < ::Spoom::Deadcode::Plugins::Base
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/deadcode/plugins/graphql.rb:27
+  # pkg:gem/spoom#lib/spoom/deadcode/plugins/graphql.rb:30
   sig { override.params(send: ::Spoom::Deadcode::Send).void }
   def on_send(send); end
+
+  private
+
+  # pkg:gem/spoom#lib/spoom/deadcode/plugins/graphql.rb:62
+  sig { params(send: ::Spoom::Deadcode::Send).void }
+  def on_argument(send); end
+
+  # pkg:gem/spoom#lib/spoom/deadcode/plugins/graphql.rb:73
+  sig { params(send: ::Spoom::Deadcode::Send).void }
+  def on_builds(send); end
+
+  # pkg:gem/spoom#lib/spoom/deadcode/plugins/graphql.rb:46
+  sig { params(send: ::Spoom::Deadcode::Send).void }
+  def on_field(send); end
 end
+
+# pkg:gem/spoom#lib/spoom/deadcode/plugins/graphql.rb:26
+Spoom::Deadcode::Plugins::GraphQL::ARGUMENT_SYMBOL_OPTION_KEYS = T.let(T.unsafe(nil), Array)
+
+# pkg:gem/spoom#lib/spoom/deadcode/plugins/graphql.rb:25
+Spoom::Deadcode::Plugins::GraphQL::FIELD_SYMBOL_OPTION_KEYS = T.let(T.unsafe(nil), Array)
 
 # pkg:gem/spoom#lib/spoom/deadcode/plugins/minitest.rb:7
 class Spoom::Deadcode::Plugins::Minitest < ::Spoom::Deadcode::Plugins::Base
@@ -2365,9 +2401,9 @@ end
 # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:7
 class Spoom::Deadcode::Remover::Error < ::Spoom::Error; end
 
-# pkg:gem/spoom#lib/spoom/deadcode/remover.rb:366
+# pkg:gem/spoom#lib/spoom/deadcode/remover.rb:469
 class Spoom::Deadcode::Remover::NodeContext
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:377
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:480
   sig do
     params(
       source: ::String,
@@ -2378,96 +2414,96 @@ class Spoom::Deadcode::Remover::NodeContext
   end
   def initialize(source, comments, node, nesting); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:491
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:594
   sig { params(node: ::Prism::Node).returns(T::Array[::Prism::Comment]) }
   def attached_comments(node); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:519
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:622
   sig { returns(T.nilable(::Prism::CallNode)) }
   def attached_sig; end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:506
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:609
   sig { returns(T::Array[::Prism::Node]) }
   def attached_sigs; end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:368
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:471
   sig { returns(T::Hash[::Integer, ::Prism::Comment]) }
   def comments; end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:479
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:582
   sig { params(start_line: ::Integer, end_line: ::Integer).returns(T::Array[::Prism::Comment]) }
   def comments_between_lines(start_line, end_line); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:374
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:477
   sig { returns(T::Array[::Prism::Node]) }
   def nesting; end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:374
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:477
   def nesting=(_arg0); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:429
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:532
   sig { returns(T.nilable(::Prism::Node)) }
   def next_node; end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:418
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:521
   sig { returns(T::Array[::Prism::Node]) }
   def next_nodes; end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:371
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:474
   sig { returns(::Prism::Node) }
   def node; end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:393
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:496
   sig { returns(::Spoom::Deadcode::Remover::NodeContext) }
   def parent_context; end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:385
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:488
   sig { returns(::Prism::Node) }
   def parent_node; end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:413
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:516
   sig { returns(T.nilable(::Prism::Node)) }
   def previous_node; end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:402
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:505
   sig { returns(T::Array[::Prism::Node]) }
   def previous_nodes; end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:434
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:537
   sig { returns(T.nilable(::Spoom::Deadcode::Remover::NodeContext)) }
   def sclass_context; end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:467
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:570
   sig { params(node: T.nilable(::Prism::Node)).returns(T::Boolean) }
   def sorbet_extend_sig?(node); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:462
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:565
   sig { params(node: T.nilable(::Prism::Node)).returns(T::Boolean) }
   def sorbet_signature?(node); end
 end
 
-# pkg:gem/spoom#lib/spoom/deadcode/remover.rb:534
+# pkg:gem/spoom#lib/spoom/deadcode/remover.rb:637
 class Spoom::Deadcode::Remover::NodeFinder < ::Spoom::Visitor
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:599
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:702
   sig { params(location: ::Spoom::Location, kind: T.nilable(::Spoom::Deadcode::Definition::Kind)).void }
   def initialize(location, kind); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:593
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:696
   sig { returns(T.nilable(::Prism::Node)) }
   def node; end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:596
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:699
   sig { returns(T::Array[::Prism::Node]) }
   def nodes_nesting; end
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:609
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:712
   sig { override.params(node: T.nilable(::Prism::Node)).void }
   def visit(node); end
 
   class << self
-    # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:537
+    # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:640
     sig do
       params(
         source: ::String,
@@ -2477,7 +2513,7 @@ class Spoom::Deadcode::Remover::NodeFinder < ::Spoom::Visitor
     end
     def find(source, location, kind); end
 
-    # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:568
+    # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:671
     sig { params(node: ::Prism::Node, kind: ::Spoom::Deadcode::Definition::Kind).returns(T::Boolean) }
     def node_match_kind?(node, kind); end
   end
@@ -2505,27 +2541,40 @@ class Spoom::Deadcode::Remover::NodeRemover
 
   private
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:151
+  # Whether `node` is a bare `private_constant`/`public_constant` call listing `name`.
+  #
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:219
+  sig { params(node: ::Prism::Node, name: ::Symbol).returns(T::Boolean) }
+  def constant_visibility_call?(node, name); end
+
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:254
   sig { params(context: ::Spoom::Deadcode::Remover::NodeContext).void }
   def delete_attr_accessor(context); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:325
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:428
   sig { params(start_char: ::Integer, end_char: ::Integer).void }
   def delete_chars(start_char, end_char); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:69
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:112
   sig { params(context: ::Spoom::Deadcode::Remover::NodeContext).void }
   def delete_constant_assignment(context); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:318
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:421
   sig { params(start_line: ::Integer, end_line: ::Integer).void }
   def delete_lines(start_line, end_line); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:255
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:358
   sig { params(context: ::Spoom::Deadcode::Remover::NodeContext).void }
   def delete_node_and_comments_and_sigs(context); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:212
+  # Drop the `:name` symbol from a `private_constant`/`public_constant` call that lists several
+  # constants, keeping the call and the other names intact.
+  #
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:233
+  sig { params(context: ::Spoom::Deadcode::Remover::NodeContext, name: ::Symbol).void }
+  def delete_symbol_argument(context, name); end
+
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:315
   sig do
     params(
       node: ::Prism::Node,
@@ -2535,11 +2584,34 @@ class Spoom::Deadcode::Remover::NodeRemover
   end
   def insert_accessor(node, send_context, was_removed:); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:330
+  # When a method is defined as the argument of a modifier call (e.g. `private def foo; end` or
+  # `private_class_method def self.foo; end`), the `def` node's parent is the call rather than the
+  # enclosing class or module body, so its sigs and comments are siblings of the call. Return a
+  # context targeting the outermost such call so they are removed together with the method.
+  #
+  # Modifiers are matched structurally rather than from a fixed list, so user-defined ones are
+  # handled too. A call only counts as a modifier when the `def` is its sole argument and it takes
+  # no block and is a standalone statement, so we never remove a call that does more than wrap
+  # the method (e.g. `register(:thing, def foo; end)` or `FOO = register(def foo; end)`).
+  #
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:80
+  sig { params(def_node: ::Prism::DefNode).returns(T.nilable(::Spoom::Deadcode::Remover::NodeContext)) }
+  def modifier_call_context(def_node); end
+
+  # A dead constant is often followed by a `private_constant`/`public_constant` call naming it.
+  # That call references the now-removed constant (a load-time `NameError` if left behind), so
+  # remove the reference too: delete the whole call when the constant is its only argument, or
+  # drop just that symbol when the call lists several constants.
+  #
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:200
+  sig { params(context: ::Spoom::Deadcode::Remover::NodeContext).void }
+  def remove_constant_visibility_call(context); end
+
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:433
   sig { params(start_char: ::Integer, end_char: ::Integer, replacement: ::String).void }
   def replace_chars(start_char, end_char, replacement); end
 
-  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:335
+  # pkg:gem/spoom#lib/spoom/deadcode/remover.rb:438
   sig do
     params(
       node: ::Prism::CallNode,
@@ -4182,11 +4254,20 @@ class Spoom::Printer
   def printt; end
 end
 
+# pkg:gem/spoom#lib/spoom/ext/prism_types.rb:5
+module Spoom::PrismTypes; end
+
+Spoom::PrismTypes::AnyScopeNode = T.type_alias { T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode) }
+
 # pkg:gem/spoom#lib/spoom/rbs.rb:5
 module Spoom::RBS; end
 
 # pkg:gem/spoom#lib/spoom/rbs.rb:71
-class Spoom::RBS::Annotation < ::Spoom::RBS::Comment; end
+class Spoom::RBS::Annotation < ::Spoom::RBS::Comment
+  # pkg:gem/spoom#lib/spoom/rbs.rb:73
+  sig { returns(T::Boolean) }
+  def abstract?; end
+end
 
 # pkg:gem/spoom#lib/spoom/rbs.rb:57
 class Spoom::RBS::Comment
@@ -4230,17 +4311,34 @@ class Spoom::RBS::Comments
   def signatures; end
 end
 
-# pkg:gem/spoom#lib/spoom/rbs.rb:75
+# pkg:gem/spoom#lib/spoom/rbs.rb:93
 module Spoom::RBS::ExtractRBSComments
-  # pkg:gem/spoom#lib/spoom/rbs.rb:77
+  # pkg:gem/spoom#lib/spoom/rbs.rb:95
   sig { params(node: ::Prism::Node).returns(::Spoom::RBS::Comments) }
   def node_rbs_comments(node); end
 end
 
-# pkg:gem/spoom#lib/spoom/rbs.rb:72
-class Spoom::RBS::Signature < ::Spoom::RBS::Comment; end
+# pkg:gem/spoom#lib/spoom/rbs.rb:78
+class Spoom::RBS::Signature < ::Spoom::RBS::Comment
+  # pkg:gem/spoom#lib/spoom/rbs.rb:85
+  sig do
+    params(
+      string: ::String,
+      location: ::Prism::Location,
+      continuation_locations: T::Array[::Prism::Location]
+    ).void
+  end
+  def initialize(string, location, continuation_locations: T.unsafe(nil)); end
 
-# pkg:gem/spoom#lib/spoom/rbs.rb:73
+  # Locations of the `#|` continuation comment lines that make up a multiline signature,
+  # in addition to the `#:` line tracked by `location`.
+  #
+  # pkg:gem/spoom#lib/spoom/rbs.rb:82
+  sig { returns(T::Array[::Prism::Location]) }
+  def continuation_locations; end
+end
+
+# pkg:gem/spoom#lib/spoom/rbs.rb:91
 class Spoom::RBS::TypeAlias < ::Spoom::RBS::Comment; end
 
 # pkg:gem/spoom#lib/spoom.rb:8
@@ -4314,7 +4412,7 @@ class Spoom::Sorbet::Config
   # puts config.options_string # "/foo /bar --ignore /baz --allowed-extension .rb"
   # ~~~
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/config.rb:64
+  # pkg:gem/spoom#lib/spoom/sorbet/config.rb:66
   sig { returns(::String) }
   def options_string; end
 
@@ -4325,28 +4423,34 @@ class Spoom::Sorbet::Config
   # pkg:gem/spoom#lib/spoom/sorbet/config.rb:30
   def paths=(_arg0); end
 
+  # pkg:gem/spoom#lib/spoom/sorbet/config.rb:30
+  def typed_overrides; end
+
+  # pkg:gem/spoom#lib/spoom/sorbet/config.rb:30
+  def typed_overrides=(_arg0); end
+
   private
 
-  # pkg:gem/spoom#lib/spoom/sorbet/config.rb:44
+  # pkg:gem/spoom#lib/spoom/sorbet/config.rb:45
   sig { params(source: ::Spoom::Sorbet::Config).void }
   def initialize_copy(source); end
 
   class << self
-    # pkg:gem/spoom#lib/spoom/sorbet/config.rb:75
+    # pkg:gem/spoom#lib/spoom/sorbet/config.rb:78
     sig { params(sorbet_config_path: ::String).returns(::Spoom::Sorbet::Config) }
     def parse_file(sorbet_config_path); end
 
-    # pkg:gem/spoom#lib/spoom/sorbet/config.rb:80
+    # pkg:gem/spoom#lib/spoom/sorbet/config.rb:83
     sig { params(sorbet_config: ::String).returns(::Spoom::Sorbet::Config) }
     def parse_string(sorbet_config); end
 
     private
 
-    # pkg:gem/spoom#lib/spoom/sorbet/config.rb:146
+    # pkg:gem/spoom#lib/spoom/sorbet/config.rb:157
     sig { params(line: ::String).returns(T::Boolean) }
     def parse_bool_option(line); end
 
-    # pkg:gem/spoom#lib/spoom/sorbet/config.rb:141
+    # pkg:gem/spoom#lib/spoom/sorbet/config.rb:152
     sig { params(line: ::String).returns(::String) }
     def parse_option(line); end
   end
@@ -4388,11 +4492,11 @@ end
 # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:9
 Spoom::Sorbet::Errors::DEFAULT_ERROR_URL_BASE = T.let(T.unsafe(nil), String)
 
-# pkg:gem/spoom#lib/spoom/sorbet/errors.rb:149
+# pkg:gem/spoom#lib/spoom/sorbet/errors.rb:171
 class Spoom::Sorbet::Errors::Error
   include ::Comparable
 
-  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:166
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:188
   sig do
     params(
       file: T.nilable(::String),
@@ -4406,79 +4510,110 @@ class Spoom::Sorbet::Errors::Error
 
   # By default errors are sorted by location
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:177
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:199
   sig { params(other: T.untyped).returns(::Integer) }
   def <=>(other); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:156
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:178
   def code; end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:153
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:175
   sig { returns(T.nilable(::String)) }
   def file; end
 
   # Other files associated with the error
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:163
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:185
   sig { returns(T::Set[::String]) }
   def files_from_error_sections; end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:156
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:178
   sig { returns(T.nilable(::Integer)) }
   def line; end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:153
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:175
   def message; end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:159
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:181
   sig { returns(T::Array[::String]) }
   def more; end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:189
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:211
   sig { returns(::REXML::Element) }
   def to_junit_xml_element; end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:184
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:206
   sig { returns(::String) }
   def to_s; end
+end
+
+# pkg:gem/spoom#lib/spoom/sorbet/errors.rb:240
+class Spoom::Sorbet::Errors::ParseResult
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:248
+  sig { params(errors: T::Array[::Spoom::Sorbet::Errors::Error], warnings: T::Array[::String]).void }
+  def initialize(errors, warnings); end
+
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:242
+  sig { returns(T::Array[::Spoom::Sorbet::Errors::Error]) }
+  def errors; end
+
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:245
+  sig { returns(T::Array[::String]) }
+  def warnings; end
 end
 
 # Parse errors from Sorbet output
 #
 # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:47
 class Spoom::Sorbet::Errors::Parser
-  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:67
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:74
   sig { params(error_url_base: ::String).void }
   def initialize(error_url_base: T.unsafe(nil)); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:74
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:82
   sig { params(output: ::String).returns(T::Array[::Spoom::Sorbet::Errors::Error]) }
   def parse(output); end
 
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:87
+  sig { params(output: ::String).returns(::Spoom::Sorbet::Errors::ParseResult) }
+  def parse_result(output); end
+
   private
 
-  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:138
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:155
   sig { params(line: ::String).void }
   def append_error(line); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:130
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:166
+  sig { params(warning: ::String).void }
+  def append_warning(warning); end
+
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:147
   sig { void }
   def close_error; end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:97
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:114
   sig { params(error_url_base: ::String).returns(::Regexp) }
   def error_line_match_regexp(error_url_base); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:114
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:131
   sig { params(line: ::String).returns(T.nilable(::Spoom::Sorbet::Errors::Error)) }
   def match_error_line(line); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:123
+  # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:140
   sig { params(error: ::Spoom::Sorbet::Errors::Error).void }
   def open_error(error); end
 
   class << self
-    # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:60
+    # Used when callers need both parsed Sorbet errors and leading stderr warnings.
+    #
+    # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:67
+    sig { params(output: ::String, error_url_base: ::String).returns(::Spoom::Sorbet::Errors::ParseResult) }
+    def parse_result(output, error_url_base: T.unsafe(nil)); end
+
+    # Used when only Sorbet errors are needed and leading stderr warnings can be ignored.
+    #
+    # pkg:gem/spoom#lib/spoom/sorbet/errors.rb:61
     sig { params(output: ::String, error_url_base: ::String).returns(T::Array[::Spoom::Sorbet::Errors::Error]) }
     def parse_string(output, error_url_base: T.unsafe(nil)); end
   end
@@ -4534,7 +4669,7 @@ class Spoom::Sorbet::Metrics::CodeMetricsVisitor < ::Spoom::Visitor
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:124
+  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:131
   sig { override.params(node: ::Prism::CallNode).void }
   def visit_call_node(node); end
 
@@ -4546,37 +4681,37 @@ class Spoom::Sorbet::Metrics::CodeMetricsVisitor < ::Spoom::Visitor
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:99
+  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:106
   sig { override.params(node: ::Prism::DefNode).void }
   def visit_def_node(node); end
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:83
+  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:90
   sig { override.params(node: ::Prism::ModuleNode).void }
   def visit_module_node(node); end
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:91
+  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:98
   sig { override.params(node: ::Prism::SingletonClassNode).void }
   def visit_singleton_class_node(node); end
 
   private
 
-  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:213
+  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:220
   sig { returns(T::Array[::Prism::CallNode]) }
   def collect_last_srb_sigs; end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:220
+  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:227
   sig { params(node: T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode)).returns(::String) }
   def node_key(node); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:167
+  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:174
   sig { params(node: ::Prism::CallNode).void }
   def visit_attr_accessor(node); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:151
+  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:158
   sig do
     params(
       node: T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode),
@@ -4585,11 +4720,11 @@ class Spoom::Sorbet::Metrics::CodeMetricsVisitor < ::Spoom::Visitor
   end
   def visit_scope(node, &block); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:187
+  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:194
   sig { params(node: ::Prism::CallNode).void }
   def visit_sig(node); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:197
+  # pkg:gem/spoom#lib/spoom/sorbet/metrics/code_metrics_visitor.rb:204
   sig { params(node: ::Prism::CallNode).void }
   def visit_type_member(node); end
 end
@@ -4703,14 +4838,22 @@ module Spoom::Sorbet::Translate
     # Converts all the RBS comments in the given Ruby code to `sig` nodes.
     # It also handles type members and class annotations.
     #
-    # pkg:gem/spoom#lib/spoom/sorbet/translate.rb:57
-    sig { params(ruby_contents: ::String, file: ::String, max_line_length: T.nilable(::Integer)).returns(::String) }
-    def rbs_comments_to_sorbet_sigs(ruby_contents, file:, max_line_length: T.unsafe(nil)); end
+    # pkg:gem/spoom#lib/spoom/sorbet/translate.rb:64
+    sig do
+      params(
+        ruby_contents: ::String,
+        file: ::String,
+        max_line_length: T.nilable(::Integer),
+        overloads_strategy: ::Symbol,
+        erase_generic_types: T::Boolean
+      ).returns(::String)
+    end
+    def rbs_comments_to_sorbet_sigs(ruby_contents, file:, max_line_length: T.unsafe(nil), overloads_strategy: T.unsafe(nil), erase_generic_types: T.unsafe(nil)); end
 
     # Converts all `T.let` and `T.cast` nodes to RBS comments in the given Ruby code.
     # It also handles type members and class annotations.
     #
-    # pkg:gem/spoom#lib/spoom/sorbet/translate.rb:72
+    # pkg:gem/spoom#lib/spoom/sorbet/translate.rb:86
     sig do
       params(
         ruby_contents: ::String,
@@ -4727,79 +4870,174 @@ module Spoom::Sorbet::Translate
     # Converts all `sig` nodes to RBS comments in the given Ruby code.
     # It also handles type members and class annotations.
     #
-    # pkg:gem/spoom#lib/spoom/sorbet/translate.rb:37
+    # pkg:gem/spoom#lib/spoom/sorbet/translate.rb:39
     sig do
       params(
         ruby_contents: ::String,
         file: ::String,
         positional_names: T::Boolean,
+        preserve_multiline_signatures: T::Boolean,
         max_line_length: T.nilable(::Integer),
         translate_generics: T::Boolean,
         translate_helpers: T::Boolean,
         translate_abstract_methods: T::Boolean
       ).returns(::String)
     end
-    def sorbet_sigs_to_rbs_comments(ruby_contents, file:, positional_names: T.unsafe(nil), max_line_length: T.unsafe(nil), translate_generics: T.unsafe(nil), translate_helpers: T.unsafe(nil), translate_abstract_methods: T.unsafe(nil)); end
+    def sorbet_sigs_to_rbs_comments(ruby_contents, file:, positional_names: T.unsafe(nil), preserve_multiline_signatures: T.unsafe(nil), max_line_length: T.unsafe(nil), translate_generics: T.unsafe(nil), translate_helpers: T.unsafe(nil), translate_abstract_methods: T.unsafe(nil)); end
 
     # Deletes all `sig` nodes from the given Ruby code.
     # It doesn't handle type members and class annotations.
     #
-    # pkg:gem/spoom#lib/spoom/sorbet/translate.rb:22
+    # pkg:gem/spoom#lib/spoom/sorbet/translate.rb:23
     sig { params(ruby_contents: ::String, file: ::String).returns(::String) }
     def strip_sorbet_sigs(ruby_contents, file:); end
   end
 end
 
-# pkg:gem/spoom#lib/spoom/sorbet/translate.rb:16
+# pkg:gem/spoom#lib/spoom/sorbet/translate.rb:17
 class Spoom::Sorbet::Translate::Error < ::Spoom::Error; end
 
-# pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:7
-class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs < ::Spoom::Sorbet::Translate::Translator
-  include ::Spoom::RBS::ExtractRBSComments
+# Walks a Prism AST and records the locations of various bits of code
+# whose locations we want to remain constant after a rewriter.
+#
+# pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:144
+class Spoom::Sorbet::Translate::LandmarkFinder < ::Prism::Visitor
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:158
+  sig { void }
+  def initialize; end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:38
-  sig { params(ruby_contents: ::String, file: ::String, max_line_length: T.nilable(::Integer)).void }
-  def initialize(ruby_contents, file:, max_line_length: T.unsafe(nil)); end
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:146
+  sig { returns(T::Hash[::String, T::Array[::Integer]]) }
+  def landmarks; end
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:86
-  sig { override.params(node: ::Prism::CallNode).void }
-  def visit_call_node(node); end
-
-  # @override
-  #
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:56
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:165
   sig { override.params(node: ::Prism::ClassNode).void }
   def visit_class_node(node); end
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:80
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:187
   sig { override.params(node: ::Prism::DefNode).void }
   def visit_def_node(node); end
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:64
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:172
   sig { override.params(node: ::Prism::ModuleNode).void }
   def visit_module_node(node); end
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:46
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:179
+  sig { override.params(node: ::Prism::SingletonClassNode).void }
+  def visit_singleton_class_node(node); end
+
+  # @override
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:199
+  sig { override.params(node: ::Prism::SourceLineNode).void }
+  def visit_source_line_node(node); end
+
+  private
+
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:207
+  sig { params(landmark_id: ::String, node: ::Prism::Node).void }
+  def record(landmark_id, node); end
+
+  class << self
+    # pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:150
+    sig { params(source: ::String).returns(T::Hash[::String, T::Array[::Integer]]) }
+    def find_landmarks_in(source); end
+  end
+end
+
+# pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:7
+module Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs
+  class << self
+    # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:23
+    sig { params(source: ::String).returns(T::Boolean) }
+    def contains_rbs_syntax?(source); end
+
+    # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:33
+    sig do
+      params(
+        ruby_contents: ::String,
+        file: ::String,
+        max_line_length: T.nilable(::Integer),
+        overloads_strategy: ::Symbol,
+        erase_generic_types: T::Boolean
+      ).returns(::String)
+    end
+    def rewrite_if_needed(ruby_contents, file:, max_line_length: T.unsafe(nil), overloads_strategy: T.unsafe(nil), erase_generic_types: T.unsafe(nil)); end
+  end
+end
+
+# @abstract
+#
+# pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb:9
+class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseRBIFormat
+  abstract!
+end
+
+# @abstract
+#
+# pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:9
+class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseTranslator < ::Spoom::Sorbet::Translate::Translator
+  include ::Spoom::RBS::ExtractRBSComments
+
+  abstract!
+
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:13
+  sig do
+    params(
+      ruby_contents: ::String,
+      file: ::String,
+      options: ::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::Options
+    ).void
+  end
+  def initialize(ruby_contents, file:, options: T.unsafe(nil)); end
+
+  # @override
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:75
+  sig { override.params(node: ::Prism::CallNode).void }
+  def visit_call_node(node); end
+
+  # @override
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:45
+  sig { override.params(node: ::Prism::ClassNode).void }
+  def visit_class_node(node); end
+
+  # @override
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:69
+  sig { override.params(node: ::Prism::DefNode).void }
+  def visit_def_node(node); end
+
+  # @override
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:53
+  sig { override.params(node: ::Prism::ModuleNode).void }
+  def visit_module_node(node); end
+
+  # @override
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:35
   sig { override.params(node: ::Prism::ProgramNode).void }
   def visit_program_node(node); end
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:72
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:61
   sig { override.params(node: ::Prism::SingletonClassNode).void }
   def visit_singleton_class_node(node); end
 
   private
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:309
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:399
   sig do
     params(
       node: T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode),
@@ -4808,46 +5046,307 @@ class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs < ::Spoom::Sorbet::Trans
   end
   def already_extends?(node, constant_regex); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:184
+  # @param is_known: true if this is an RBS annotation that we recognize
+  #                  false for some other `@`-prefixed thing, like a documentation `@param` tag.
+  # @abstract
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:333
+  sig do
+    abstract
+      .params(
+        annotation: ::Spoom::RBS::Annotation,
+        parent_node: T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode),
+        insert_pos: ::Integer,
+        sorbet_replacement: T.nilable(::String)
+      ).void
+  end
+  def apply_class_annotation(annotation, parent_node:, insert_pos:, sorbet_replacement:); end
+
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:221
   sig { params(node: T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode)).void }
   def apply_class_annotations(node); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:285
-  sig { params(annotations: T::Array[::Spoom::RBS::Annotation], sig: ::RBI::Sig).void }
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:346
+  sig do
+    params(
+      annotations: T::Array[::Spoom::RBS::Annotation],
+      sig: ::RBI::Sig
+    ).returns(T::Array[::Spoom::RBS::Annotation])
+  end
   def apply_member_annotations(annotations, sig); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:361
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:198
+  sig do
+    params(
+      signatures: T::Array[::Spoom::RBS::Signature],
+      method_name: ::String,
+      location: ::String
+    ).returns(T::Array[::Spoom::RBS::Signature])
+  end
+  def apply_overloads_strategy(signatures, method_name:, location:); end
+
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:451
   sig { params(comments: T::Array[::Prism::Comment]).void }
   def apply_type_aliases(comments); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:325
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:415
   sig { params(comments: T::Array[::Prism::Comment]).returns(T::Array[::Spoom::RBS::TypeAlias]) }
   def collect_type_aliases(comments); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:142
+  # @abstract
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:396
+  sig do
+    abstract
+      .params(
+        mixin_name: ::String,
+        into: T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode),
+        at: ::Integer
+      ).void
+  end
+  def extend_with(mixin_name, into:, at:); end
+
+  # Inserts a single `type_member` declaration into the class/module body.
+  # @abstract
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:343
+  sig do
+    abstract
+      .params(
+        type_member: ::String,
+        parent_node: T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode),
+        insert_pos: ::Integer
+      ).void
+  end
+  def insert_type_member(type_member, parent_node:, insert_pos:); end
+
+  # @overridable
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:489
+  sig { overridable.params(of: ::String, to_height_of: ::Spoom::RBS::Comment).returns(::String) }
+  def pad_out_line_count(of:, to_height_of:); end
+
+  # @param is_known: true if this is an RBS annotation that we recognize
+  #                  false for some other `@`-prefixed thing, like a documentation `@param` tag.
+  # @overridable
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:392
+  sig { overridable.params(annotation: ::Spoom::RBS::Annotation, is_known: T::Boolean).void }
+  def rewrite_annotation(annotation, is_known:); end
+
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:143
   sig { params(def_node: ::Prism::DefNode, comments: ::Spoom::RBS::Comments).void }
   def rewrite_def(def_node, comments); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:104
+  # Called for every overloaded method sig that we discard because it wasn't the last one.
+  # @abstract
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:218
+  sig { abstract.params(signature: ::Spoom::RBS::Signature).void }
+  def rewrite_discarded_overload(signature); end
+
+  # Rewrites the member annotation comments in the source. Called once per method,
+  # regardless of how many overloaded signatures share the annotations, to avoid
+  # emitting duplicate markers.
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:382
+  sig { params(annotations: T::Array[::Spoom::RBS::Annotation], known: T::Array[::Spoom::RBS::Annotation]).void }
+  def rewrite_member_annotations(annotations, known:); end
+
+  # Rewrites the `#: [...]` type params comment (e.g. delete it, or mark it as translated).
+  # @abstract
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:338
+  sig { abstract.params(signature: ::Spoom::RBS::Signature, type_params: T::Array[::RBS::AST::TypeParam]).void }
+  def rewrite_type_params_signature(signature, type_params:); end
+
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb:93
   sig { params(node: ::Prism::CallNode).void }
   def visit_attr(node); end
+end
+
+# pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb:12
+class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::HumanReadableRBIFormat < ::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseRBIFormat
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb:19
+  sig { params(max_line_length: T.nilable(::Integer)).void }
+  def initialize(max_line_length: T.unsafe(nil)); end
+
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb:14
+  sig { returns(T.nilable(::Integer)) }
+  def max_line_length; end
 
   class << self
-    # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:25
-    sig { params(source: ::String).returns(T::Boolean) }
-    def contains_rbs_syntax?(source); end
-
-    # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:30
-    sig { params(ruby_contents: ::String, file: ::String, max_line_length: T.nilable(::Integer)).returns(::String) }
-    def rewrite_if_needed(ruby_contents, file:, max_line_length: T.unsafe(nil)); end
+    # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb:29
+    sig { returns(::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::HumanReadableRBIFormat) }
+    def default; end
   end
 end
 
-# pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:10
-Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::RBS_ANNOTATION_MARKERS = T.let(T.unsafe(nil), Array)
+# pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/human_readable_translator.rb:11
+class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::HumanReadableTranslator < ::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseTranslator
+  private
 
-# pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb:20
-Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::RBS_REWRITE_PATTERN = T.let(T.unsafe(nil), Regexp)
+  # @override
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/human_readable_translator.rb:30
+  sig do
+    override
+      .params(
+        annotation: ::Spoom::RBS::Annotation,
+        parent_node: T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode),
+        insert_pos: ::Integer,
+        sorbet_replacement: T.nilable(::String)
+      ).void
+  end
+  def apply_class_annotation(annotation, parent_node:, insert_pos:, sorbet_replacement:); end
+
+  # @override
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/human_readable_translator.rb:61
+  sig { override.params(mixin_name: ::String, into: ::Prism::Node, at: ::Integer).void }
+  def extend_with(mixin_name, into:, at:); end
+
+  # @override
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/human_readable_translator.rb:53
+  sig do
+    override
+      .params(
+        type_member: ::String,
+        parent_node: T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode),
+        insert_pos: ::Integer
+      ).void
+  end
+  def insert_type_member(type_member, parent_node:, insert_pos:); end
+
+  # Deletes the discarded overload from the source codes
+  # @override
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/human_readable_translator.rb:17
+  sig { override.params(signature: ::Spoom::RBS::Signature).void }
+  def rewrite_discarded_overload(signature); end
+
+  # @override
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/human_readable_translator.rb:45
+  sig { override.params(signature: ::Spoom::RBS::Signature, type_params: T::Array[::RBS::AST::TypeParam]).void }
+  def rewrite_type_params_signature(signature, type_params:); end
+end
+
+# pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb:33
+class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::LineMatchedRBIFormat < ::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseRBIFormat
+  class << self
+    # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb:37
+    sig { returns(::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::LineMatchedRBIFormat) }
+    def default; end
+  end
+end
+
+# pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/line_matching_translator.rb:11
+class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::LineMatchingTranslator < ::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseTranslator
+  private
+
+  # @override
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/line_matching_translator.rb:32
+  sig do
+    override
+      .params(
+        annotation: ::Spoom::RBS::Annotation,
+        parent_node: T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode),
+        insert_pos: ::Integer,
+        sorbet_replacement: T.nilable(::String)
+      ).void
+  end
+  def apply_class_annotation(annotation, parent_node:, insert_pos:, sorbet_replacement:); end
+
+  # @override
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/line_matching_translator.rb:85
+  sig { override.params(mixin_name: ::String, into: ::Prism::Node, at: ::Integer).void }
+  def extend_with(mixin_name, into:, at:); end
+
+  # @override
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/line_matching_translator.rb:71
+  sig do
+    override
+      .params(
+        type_member: ::String,
+        parent_node: T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode),
+        insert_pos: ::Integer
+      ).void
+  end
+  def insert_type_member(type_member, parent_node:, insert_pos:); end
+
+  # @override
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/line_matching_translator.rb:93
+  sig { override.params(of: ::String, to_height_of: ::Spoom::RBS::Comment).returns(::String) }
+  def pad_out_line_count(of:, to_height_of:); end
+
+  # @override
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/line_matching_translator.rb:77
+  sig { override.params(annotation: ::Spoom::RBS::Annotation, is_known: T::Boolean).void }
+  def rewrite_annotation(annotation, is_known:); end
+
+  # Comments out the discarded overload
+  # @override
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/line_matching_translator.rb:17
+  sig { override.params(signature: ::Spoom::RBS::Signature).void }
+  def rewrite_discarded_overload(signature); end
+
+  # @override
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/line_matching_translator.rb:51
+  sig { override.params(signature: ::Spoom::RBS::Signature, type_params: T::Array[::RBS::AST::TypeParam]).void }
+  def rewrite_type_params_signature(signature, type_params:); end
+end
+
+# pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb:41
+class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::Options
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb:65
+  sig do
+    params(
+      overloads_strategy: ::Symbol,
+      erase_generic_types: T::Boolean,
+      output_format: ::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseRBIFormat,
+      translate_abstract_methods: T::Boolean
+    ).void
+  end
+  def initialize(overloads_strategy: T.unsafe(nil), erase_generic_types: T.unsafe(nil), output_format: T.unsafe(nil), translate_abstract_methods: T.unsafe(nil)); end
+
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb:48
+  sig { returns(T::Boolean) }
+  def erase_generic_types; end
+
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb:54
+  sig { returns(::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseRBIFormat) }
+  def output_format; end
+
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb:43
+  sig { returns(::Symbol) }
+  def overloads_strategy; end
+
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb:51
+  sig { returns(::RBI::RBS::MethodTypeTranslator::Options) }
+  def rbi_options; end
+
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb:57
+  sig { returns(T::Boolean) }
+  def translate_abstract_methods; end
+
+  class << self
+    # pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb:88
+    sig { returns(::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::Options) }
+    def default; end
+  end
+end
+
+# pkg:gem/spoom#lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb:45
+Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::Options::ALLOWED_OVERLOAD_STRATEGIES = T.let(T.unsafe(nil), Array)
 
 # Translates Sorbet assertions to RBS comments.
 #
@@ -4881,44 +5380,56 @@ class Spoom::Sorbet::Translate::SorbetAssertionsToRBSComments < ::Spoom::Sorbet:
 
   private
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb:176
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb:178
   sig { params(node: ::Prism::Node).returns(T::Boolean) }
   def at_end_of_line?(node); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb:118
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb:120
   sig { params(call: ::Prism::CallNode).returns(::String) }
   def build_rbs_annotation(call); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb:216
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb:265
   sig { params(assign: ::Prism::Node, value: ::Prism::Node).returns(::String) }
   def dedent_value(assign, value); end
 
   # Extract any trailing comment after the node
   # Returns [comment_text, comment_end_offset] or [nil, nil] if no comment or RBS annotation
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb:196
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb:198
   sig { params(node: ::Prism::Node).returns([T.nilable(::String), T.nilable(::Integer)]) }
   def extract_trailing_comment(node); end
 
   # Check if the node has an RBS annotation comment (#:) after it
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb:185
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb:187
   sig { params(node: ::Prism::Node).returns(T::Boolean) }
   def has_rbs_annotation?(node); end
+
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb:218
+  sig { params(node: ::Prism::Node, replace_end_offset: ::Integer).returns(T.nilable(::String)) }
+  def heredoc_body_within_range(node, replace_end_offset); end
+
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb:232
+  sig { params(node: ::Prism::Node).returns(T::Array[::Integer]) }
+  def heredoc_end_offsets(node); end
 
   # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb:71
   sig { params(node: ::Prism::Node).returns(T::Boolean) }
   def maybe_translate_assertion(node); end
 
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb:254
+  sig { params(node: ::Prism::Node).returns(T::Boolean) }
+  def string_literal?(node); end
+
   # Is this node a `T` or `::T` constant?
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb:143
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb:145
   sig { params(node: T.nilable(::Prism::Node)).returns(T::Boolean) }
   def t?(node); end
 
   # Is this node a `T.let` or `T.cast`?
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb:156
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb:158
   sig { params(node: ::Prism::CallNode).returns(T::Boolean) }
   def translatable_annotation?(node); end
 end
@@ -4931,59 +5442,60 @@ Spoom::Sorbet::Translate::SorbetAssertionsToRBSComments::LINE_BREAK = T.let(T.un
 #
 # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:9
 class Spoom::Sorbet::Translate::SorbetSigsToRBSComments < ::Spoom::Sorbet::Translate::Translator
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:19
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:20
   sig do
     params(
       ruby_contents: ::String,
       file: ::String,
       positional_names: T::Boolean,
+      preserve_multiline_signatures: T::Boolean,
       max_line_length: T.nilable(::Integer),
       translate_generics: T::Boolean,
       translate_helpers: T::Boolean,
       translate_abstract_methods: T::Boolean
     ).void
   end
-  def initialize(ruby_contents, file:, positional_names:, max_line_length: T.unsafe(nil), translate_generics: T.unsafe(nil), translate_helpers: T.unsafe(nil), translate_abstract_methods: T.unsafe(nil)); end
+  def initialize(ruby_contents, file:, positional_names:, preserve_multiline_signatures: T.unsafe(nil), max_line_length: T.unsafe(nil), translate_generics: T.unsafe(nil), translate_helpers: T.unsafe(nil), translate_abstract_methods: T.unsafe(nil)); end
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:100
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:109
   sig { override.params(node: ::Prism::CallNode).void }
   def visit_call_node(node); end
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:46
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:50
   sig { override.params(node: ::Prism::ClassNode).void }
   def visit_class_node(node); end
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:119
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:128
   sig { override.params(node: ::Prism::ConstantWriteNode).void }
   def visit_constant_write_node(node); end
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:64
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:68
   sig { override.params(node: ::Prism::DefNode).void }
   def visit_def_node(node); end
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:52
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:56
   sig { override.params(node: ::Prism::ModuleNode).void }
   def visit_module_node(node); end
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:58
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:62
   sig { override.params(node: ::Prism::SingletonClassNode).void }
   def visit_singleton_class_node(node); end
 
   private
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:233
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:242
   sig do
     params(
       parent: T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode),
@@ -4992,41 +5504,47 @@ class Spoom::Sorbet::Translate::SorbetSigsToRBSComments < ::Spoom::Sorbet::Trans
   end
   def apply_class_annotation(parent, node); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:277
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:286
   sig { params(sigs: T::Array[[::Prism::CallNode, ::RBI::Sig]]).void }
   def apply_member_annotations(sigs); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:313
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:322
   sig { params(node: ::Prism::ConstantWriteNode).returns(::String) }
   def build_type_member_string(node); end
 
   # Collects the last signatures visited and clears the current list
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:384
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:393
   sig { returns(T::Array[[::Prism::CallNode, ::RBI::Sig]]) }
   def collect_last_sigs; end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:371
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:380
   sig { void }
   def delete_extend_t_generics; end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:359
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:368
   sig { void }
   def delete_extend_t_helpers; end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:391
-  sig { params(indent: ::Integer, block: T.proc.params(arg0: ::RBI::RBSPrinter).void).returns(::String) }
-  def rbs_print(indent, &block); end
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:400
+  sig do
+    params(
+      indent: ::Integer,
+      preserve_multiline_signatures: T::Boolean,
+      block: T.proc.params(arg0: ::RBI::RBSPrinter).void
+    ).returns(::String)
+  end
+  def rbs_print(indent, preserve_multiline_signatures:, &block); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:191
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:200
   sig { params(node: ::Prism::CallNode).void }
   def visit_attr(node); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:215
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:224
   sig { params(node: ::Prism::CallNode).void }
   def visit_extend(node); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:138
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:147
   sig do
     params(
       node: T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode),
@@ -5035,7 +5553,7 @@ class Spoom::Sorbet::Translate::SorbetSigsToRBSComments < ::Spoom::Sorbet::Trans
   end
   def visit_scope(node, &block); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:179
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb:188
   sig { params(node: ::Prism::CallNode).void }
   def visit_sig(node); end
 end
@@ -5086,6 +5604,88 @@ class Spoom::Sorbet::Translate::Translator < ::Spoom::Visitor
   sig { params(node: ::Prism::CallNode).returns(T::Boolean) }
   def sorbet_sig?(node); end
 end
+
+# The outcome of comparing an original source with its rewritten form.
+#
+# pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:63
+class Spoom::Sorbet::Translate::ValidationResult
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:87
+  sig do
+    params(
+      missing_from_rewritten_output: T::Array[{landmark_id: ::String, line: ::Integer}],
+      excess_in_rewritten_output: T::Array[{landmark_id: ::String, line: ::Integer}],
+      on_wrong_line: T::Array[{landmark_id: ::String, expected: T::Array[::Integer], actual: T::Array[::Integer]}]
+    ).void
+  end
+  def initialize(missing_from_rewritten_output:, excess_in_rewritten_output:, on_wrong_line:); end
+
+  # Human-readable, one-per-line descriptions of every difference. Empty when
+  # the result is valid.
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:104
+  sig { returns(T::Array[::String]) }
+  def errors; end
+
+  # Landmarks present in the rewrite with no match in the original.
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:76
+  sig { returns(T::Array[{landmark_id: ::String, line: ::Integer}]) }
+  def excess_in_rewritten_output; end
+
+  # Landmarks present in the original but missing from the rewrite.
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:72
+  sig { returns(T::Array[{landmark_id: ::String, line: ::Integer}]) }
+  def missing_from_rewritten_output; end
+
+  # Landmarks present in both sources, but that moved to a different line.
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:80
+  sig { returns(T::Array[{landmark_id: ::String, expected: T::Array[::Integer], actual: T::Array[::Integer]}]) }
+  def on_wrong_line; end
+
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:119
+  sig { params(printer: T.untyped).void }
+  def pretty_print(printer); end
+
+  # True when every landmark survived the rewrite on its original line.
+  #
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:95
+  sig { returns(T::Boolean) }
+  def valid?; end
+
+  private
+
+  # pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:137
+  sig { params(lines: T::Array[::Integer]).returns(::String) }
+  def format_lines(lines); end
+end
+
+Spoom::Sorbet::Translate::ValidationResult::LandmarkLocation = T.type_alias { {landmark_id: ::String, line: ::Integer} }
+Spoom::Sorbet::Translate::ValidationResult::MovedLandmark = T.type_alias { {landmark_id: ::String, expected: T::Array[::Integer], actual: T::Array[::Integer]} }
+
+# Checks that a translation preserved the lines of every "landmark" (e.g. classes, method defs, and so on)
+# so line numbers in the rewritten output still line up with the original source.
+#
+# pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:9
+module Spoom::Sorbet::Translate::Validator
+  class << self
+    # Compares the landmarks in both sources and returns a result describing
+    # what changed:
+    #   missing_from_rewritten_output - dropped: an occurrence in the original
+    #                                   that is gone from the rewrite
+    #   excess_in_rewritten_output    - added: an occurrence in the rewrite with
+    #                                   no match in the original
+    #   on_wrong_line                 - survived but moved to a different line
+    #
+    # pkg:gem/spoom#lib/spoom/sorbet/translate/validator.rb:25
+    sig { params(original: ::String, rewritten: ::String).returns(::Spoom::Sorbet::Translate::ValidationResult) }
+    def validate(original, rewritten); end
+  end
+end
+
+Spoom::Sorbet::Translate::Validator::LandmarkID = T.type_alias { ::String }
+Spoom::Sorbet::Translate::Validator::Landmarks = T.type_alias { T::Hash[::String, T::Array[::Integer]] }
 
 # This module provides a simple API to rewrite source code.
 #

--- a/sorbet/rbi/gems/tapioca@0.19.2.rbi
+++ b/sorbet/rbi/gems/tapioca@0.19.2.rbi
@@ -189,6 +189,25 @@ module T::Helpers
   def requires_ancestor(&block); end
 end
 
+# pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_type_patch.rb:28
+module T::Private::Casts
+  class << self
+    # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_type_patch.rb:34
+    def cast(value, type, cast_method); end
+  end
+end
+
+# pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_type_patch.rb:29
+module T::Private::Casts::TapiocaGenericTypeCastPatch
+  # https://github.com/sorbet/sorbet/commit/b8d64c7fd9a08e2b9159b5d592bc2de6d586b44a
+  # inlines the Module fast path in `T.let`, `T.cast`, `T.bind`, and
+  # `T.assert_type!`, so generic module clones can reach this cast path
+  # without going through `T::Utils::Private::TapiocaGenericTypeCoercePatch`.
+  #
+  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_type_patch.rb:34
+  def cast(value, type, cast_method); end
+end
+
 # pkg:gem/tapioca#lib/tapioca/sorbet_ext/proc_bind_patch.rb:28
 module T::Private::Methods
   class << self
@@ -243,17 +262,20 @@ module T::Types::Simple::NamePatch
   def name; end
 end
 
-# pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:87
+# pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_type_patch.rb:6
 module T::Utils::Private
   class << self
-    # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:89
+    # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_type_patch.rb:10
     def coerce_and_check_module_types(val, check_val, check_module_type); end
   end
 end
 
-# pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:88
-module T::Utils::Private::PrivateCoercePatch
-  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:89
+# Preserve Tapioca's generic type variables and instantiated generic
+# names when Sorbet coerces them into runtime types.
+#
+# pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_type_patch.rb:9
+module T::Utils::Private::TapiocaGenericTypeCoercePatch
+  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_type_patch.rb:10
   def coerce_and_check_module_types(val, check_val, check_module_type); end
 end
 
@@ -271,6 +293,9 @@ end
 # For example,
 # the package URL for this Ruby package at version 0.1.0 is
 # `pkg:ruby/mattt/packageurl-ruby@0.1.0`.
+# This code rewrites RBS comments back into Sorbet's signatures as the files are being loaded.
+# This will allow `sorbet-runtime` to wrap the methods as if they were originally written with the `sig{}` blocks.
+# This will in turn allow Tapioca to use this signatures to generate typed RBI files.
 #
 # pkg:gem/tapioca#lib/tapioca/runtime/trackers/autoload.rb:4
 module Tapioca; end
@@ -328,22 +353,22 @@ class Tapioca::Cli < ::Thor
   include ::Tapioca::ConfigHelper
   include ::Tapioca::EnvHelper
 
-  # pkg:gem/tapioca#lib/tapioca/cli.rb:373
+  # pkg:gem/tapioca#lib/tapioca/cli.rb:383
   def __print_version; end
 
-  # pkg:gem/tapioca#lib/tapioca/cli.rb:355
+  # pkg:gem/tapioca#lib/tapioca/cli.rb:365
   def annotations; end
 
-  # pkg:gem/tapioca#lib/tapioca/cli.rb:327
+  # pkg:gem/tapioca#lib/tapioca/cli.rb:337
   def check_shims; end
 
   # pkg:gem/tapioca#lib/tapioca/cli.rb:46
   def configure; end
 
-  # pkg:gem/tapioca#lib/tapioca/cli.rb:146
+  # pkg:gem/tapioca#lib/tapioca/cli.rb:150
   def dsl(*constant_or_paths); end
 
-  # pkg:gem/tapioca#lib/tapioca/cli.rb:269
+  # pkg:gem/tapioca#lib/tapioca/cli.rb:279
   def gem(*gems); end
 
   # pkg:gem/tapioca#lib/tapioca/cli.rb:27
@@ -357,20 +382,20 @@ class Tapioca::Cli < ::Thor
 
   private
 
-  # pkg:gem/tapioca#lib/tapioca/cli.rb:398
+  # pkg:gem/tapioca#lib/tapioca/cli.rb:408
   def print_init_next_steps; end
 
   class << self
     # Indicates that we are running from the LSP, set using the `addon_mode!` method
     #
-    # pkg:gem/tapioca#lib/tapioca/cli.rb:382
+    # pkg:gem/tapioca#lib/tapioca/cli.rb:392
     def addon_mode; end
 
-    # pkg:gem/tapioca#lib/tapioca/cli.rb:385
+    # pkg:gem/tapioca#lib/tapioca/cli.rb:395
     sig { void }
     def addon_mode!; end
 
-    # pkg:gem/tapioca#lib/tapioca/cli.rb:390
+    # pkg:gem/tapioca#lib/tapioca/cli.rb:400
     sig { returns(T::Boolean) }
     def exit_on_failure?; end
   end
@@ -435,15 +460,15 @@ class Tapioca::Commands::AbstractDsl < ::Tapioca::Commands::CommandWithoutTracke
 
   private
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:88
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:93
   sig { returns(T::Array[::String]) }
   def all_requested_constants; end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:284
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:289
   sig { params(cause: ::Symbol, files: T::Array[::String]).returns(::String) }
   def build_error_for_files(cause, files); end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:208
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:213
   sig do
     params(
       constant_name: ::String,
@@ -454,7 +479,7 @@ class Tapioca::Commands::AbstractDsl < ::Tapioca::Commands::CommandWithoutTracke
   end
   def compile_dsl_rbi(constant_name, rbi, outpath: T.unsafe(nil), quiet: T.unsafe(nil)); end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:150
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:155
   sig do
     params(
       constant_names: T::Array[::String],
@@ -463,27 +488,27 @@ class Tapioca::Commands::AbstractDsl < ::Tapioca::Commands::CommandWithoutTracke
   end
   def constantize(constant_names, ignore_missing: T.unsafe(nil)); end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:175
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:180
   sig { params(compiler_names: T::Array[::String]).returns(T::Array[T.class_of(Tapioca::Dsl::Compiler)]) }
   def constantize_compilers(compiler_names); end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:344
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:349
   sig { returns(T::Array[::String]) }
   def constants_from_requested_paths; end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:111
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:116
   sig { returns(::Tapioca::Dsl::Pipeline) }
   def create_pipeline; end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:247
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:252
   sig { params(constant_name: ::String).returns(::Pathname) }
   def dsl_rbi_filename(constant_name); end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:136
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:141
   sig { params(requested_constants: T::Array[::String], path: ::Pathname).returns(T::Set[::Pathname]) }
   def existing_rbi_filenames(requested_constants, path: T.unsafe(nil)); end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:339
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:344
   sig { params(constant: ::String).returns(::String) }
   def generate_command_for(constant); end
 
@@ -491,43 +516,43 @@ class Tapioca::Commands::AbstractDsl < ::Tapioca::Commands::CommandWithoutTracke
   sig { params(outpath: ::Pathname, quiet: T::Boolean).returns(T::Set[::Pathname]) }
   def generate_dsl_rbi_files(outpath, quiet:); end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:98
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:103
   sig { void }
   def load_application; end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:226
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:231
   sig { params(dir: ::Pathname).void }
   def perform_dsl_verification(dir); end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:93
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:98
   sig { returns(::Tapioca::Dsl::Pipeline) }
   def pipeline; end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:235
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:240
   sig { params(files: T::Set[::Pathname]).void }
   def purge_stale_dsl_rbi_files(files); end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:334
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:339
   sig { params(constant: ::String).returns(::String) }
   def rbi_filename_for(constant); end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:315
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:320
   sig { params(path: ::Pathname).returns(T::Array[::Pathname]) }
   def rbi_files_in(path); end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:293
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:298
   sig { params(diff: T::Hash[::String, ::Symbol], command: ::Symbol).void }
   def report_diff_and_exit_if_out_of_date(diff, command); end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:195
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:200
   sig { params(name: ::String).returns(T.nilable(T.class_of(Tapioca::Dsl::Compiler))) }
   def resolve(name); end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:322
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:327
   sig { params(class_name: ::String).returns(::String) }
   def underscore(class_name); end
 
-  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:252
+  # pkg:gem/tapioca#lib/tapioca/commands/abstract_dsl.rb:257
   sig { params(tmp_dir: ::Pathname).returns(T::Hash[::String, ::Symbol]) }
   def verify_dsl_rbi(tmp_dir:); end
 end
@@ -869,11 +894,15 @@ end
 
 # pkg:gem/tapioca#lib/tapioca/commands/dsl_generate.rb:6
 class Tapioca::Commands::DslGenerate < ::Tapioca::Commands::AbstractDsl
+  # pkg:gem/tapioca#lib/tapioca/commands/dsl_generate.rb:8
+  sig { params(only_bootsnap_rbs_cache: T::Boolean, kwargs: T.untyped).void }
+  def initialize(only_bootsnap_rbs_cache: T.unsafe(nil), **kwargs); end
+
   private
 
   # @override
   #
-  # pkg:gem/tapioca#lib/tapioca/commands/dsl_generate.rb:11
+  # pkg:gem/tapioca#lib/tapioca/commands/dsl_generate.rb:17
   sig { override.void }
   def execute; end
 end
@@ -2074,7 +2103,7 @@ Tapioca::Dsl::Compilers::ActiveRecordColumns::ColumnTypeOption = Tapioca::Dsl::H
 #   include GeneratedDelegatedTypeMethods
 #
 #   module GeneratedDelegatedTypeMethods
-#     sig { params(args: T.untyped).returns(T.any(Message, Comment)) }
+#     sig { params(args: T.untyped).returns(T.any(::Message, ::Comment)) }
 #     def build_entryable(*args); end
 #
 #     sig { returns(Class) }
@@ -2086,7 +2115,7 @@ Tapioca::Dsl::Compilers::ActiveRecordColumns::ColumnTypeOption = Tapioca::Dsl::H
 #     sig { returns(T::Boolean) }
 #     def message?; end
 #
-#     sig { returns(T.nilable(Message)) }
+#     sig { returns(T.nilable(::Message)) }
 #     def message; end
 #
 #     sig { returns(T.nilable(Integer)) }
@@ -2095,7 +2124,7 @@ Tapioca::Dsl::Compilers::ActiveRecordColumns::ColumnTypeOption = Tapioca::Dsl::H
 #     sig { returns(T::Boolean) }
 #     def comment?; end
 #
-#     sig { returns(T.nilable(Comment)) }
+#     sig { returns(T.nilable(::Comment)) }
 #     def comment; end
 #
 #     sig { returns(T.nilable(Integer)) }
@@ -2114,37 +2143,113 @@ class Tapioca::Dsl::Compilers::ActiveRecordDelegatedTypes < ::Tapioca::Dsl::Comp
 
   # @override
   #
-  # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:75
+  # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:78
   sig { override.void }
   def decorate; end
 
   private
 
-  # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:103
-  sig { params(mod: ::RBI::Scope, role: ::Symbol, types: T::Array[::String]).void }
-  def populate_role_accessors(mod, role, types); end
+  # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:199
+  sig { params(type: ::String, role: ::Symbol).returns(::String) }
+  def add_unresolvable_type_error(type, role); end
 
-  # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:131
-  sig { params(mod: ::RBI::Scope, role: ::Symbol, type: ::String, options: T::Hash[::Symbol, T.untyped]).void }
-  def populate_type_helper(mod, role, type, options); end
+  # Collapses to `T.untyped` if any member is `T.untyped`, since `T.any(::Foo, T.untyped)`
+  # is equivalent to `T.untyped` in Sorbet and the per-type error has already been recorded.
+  #
+  # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:167
+  sig do
+    params(
+      resolved_types: T::Array[::Tapioca::Dsl::Compilers::ActiveRecordDelegatedTypes::ResolvedType]
+    ).returns(::String)
+  end
+  def build_return_type(resolved_types); end
 
-  # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:124
+  # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:109
   sig do
     params(
       mod: ::RBI::Scope,
       role: ::Symbol,
-      types: T::Array[::String],
+      resolved_types: T::Array[::Tapioca::Dsl::Compilers::ActiveRecordDelegatedTypes::ResolvedType]
+    ).void
+  end
+  def populate_role_accessors(mod, role, resolved_types); end
+
+  # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:137
+  sig do
+    params(
+      mod: ::RBI::Scope,
+      role: ::Symbol,
+      resolved_type: ::Tapioca::Dsl::Compilers::ActiveRecordDelegatedTypes::ResolvedType,
       options: T::Hash[::Symbol, T.untyped]
     ).void
   end
-  def populate_type_helpers(mod, role, types, options); end
+  def populate_type_helper(mod, role, resolved_type, options); end
+
+  # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:130
+  sig do
+    params(
+      mod: ::RBI::Scope,
+      role: ::Symbol,
+      resolved_types: T::Array[::Tapioca::Dsl::Compilers::ActiveRecordDelegatedTypes::ResolvedType],
+      options: T::Hash[::Symbol, T.untyped]
+    ).void
+  end
+  def populate_type_helpers(mod, role, resolved_types, options); end
+
+  # Resolves a delegated type entry to a fully-qualified constant name. The strings passed
+  # to `delegated_type(..., types: %w[...])` are written verbatim into the generated RBI,
+  # but the surrounding `class A::B::C` scope omits `A` and `A::B` from Sorbet's lexical
+  # nesting, so a bare `D` reference fails to resolve to `A::B::D` even when that constant
+  # exists. `compute_type` is `ActiveRecord::Base`'s own (private) namespace-walking lookup
+  # — the same one Rails uses for STI and polymorphic associations — so it resolves both
+  # bare and fully-qualified names. When the constant can't be resolved (NameError) or its
+  # qualified name can't be derived (anonymous class) we record a compiler error and emit
+  # `T.untyped`, which both surfaces the problem and keeps the generated RBI type-checkable.
+  #
+  # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:188
+  sig { params(type: ::String, role: ::Symbol).returns(::String) }
+  def qualified_type_name(type, role); end
 
   class << self
     # @override
     #
-    # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:95
+    # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:101
     sig { override.returns(T::Enumerable[T::Module[T.anything]]) }
     def gather_constants; end
+  end
+end
+
+# A delegated type entry paired with the fully-qualified constant name it resolves to.
+#
+# pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:74
+class Tapioca::Dsl::Compilers::ActiveRecordDelegatedTypes::ResolvedType < ::Struct
+  # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:74
+  def qualified_name; end
+
+  # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:74
+  def qualified_name=(_); end
+
+  # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:74
+  def raw_name; end
+
+  # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:74
+  def raw_name=(_); end
+
+  class << self
+    # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:74
+    def [](*_arg0); end
+
+    # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:74
+    def inspect; end
+
+    # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:74
+    def keyword_init?; end
+
+    # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:74
+    def members; end
+
+    # pkg:gem/tapioca#lib/tapioca/dsl/compilers/active_record_delegated_types.rb:74
+    def new(*_arg0); end
   end
 end
 
@@ -3953,15 +4058,15 @@ module Tapioca::Dsl::Helpers::GraphqlTypeHelper
 
   private
 
-  # pkg:gem/tapioca#lib/tapioca/dsl/helpers/graphql_type_helper.rb:112
+  # pkg:gem/tapioca#lib/tapioca/dsl/helpers/graphql_type_helper.rb:114
   sig { params(argument: ::GraphQL::Schema::Argument).returns(T::Boolean) }
   def has_replaceable_default?(argument); end
 
-  # pkg:gem/tapioca#lib/tapioca/dsl/helpers/graphql_type_helper.rb:99
+  # pkg:gem/tapioca#lib/tapioca/dsl/helpers/graphql_type_helper.rb:101
   sig { params(constant: T::Module[T.anything]).returns(::String) }
   def type_for_constant(constant); end
 
-  # pkg:gem/tapioca#lib/tapioca/dsl/helpers/graphql_type_helper.rb:117
+  # pkg:gem/tapioca#lib/tapioca/dsl/helpers/graphql_type_helper.rb:119
   sig { params(return_type: T.nilable(::T::Types::Base)).returns(T::Boolean) }
   def valid_return_type?(return_type); end
 end
@@ -4031,13 +4136,13 @@ class Tapioca::Dsl::Pipeline
 
   private
 
-  # pkg:gem/tapioca#lib/tapioca/dsl/pipeline.rb:197
+  # pkg:gem/tapioca#lib/tapioca/dsl/pipeline.rb:173
   sig { void }
   def abort_if_pending_migrations!; end
 
   # pkg:gem/tapioca#lib/tapioca/dsl/pipeline.rb:143
   sig { params(constants: T::Set[T::Module[T.anything]]).returns(T::Set[T::Module[T.anything]]) }
-  def filter_anonymous_and_reloaded_constants(constants); end
+  def filter_anonymous_constants(constants); end
 
   # pkg:gem/tapioca#lib/tapioca/dsl/pipeline.rb:113
   sig do
@@ -4058,11 +4163,11 @@ class Tapioca::Dsl::Pipeline
   end
   def gather_constants(requested_constants, requested_paths, skipped_constants); end
 
-  # pkg:gem/tapioca#lib/tapioca/dsl/pipeline.rb:172
+  # pkg:gem/tapioca#lib/tapioca/dsl/pipeline.rb:148
   sig { params(constant: T::Module[T.anything]).returns(T.nilable(::RBI::File)) }
   def rbi_for_constant(constant); end
 
-  # pkg:gem/tapioca#lib/tapioca/dsl/pipeline.rb:191
+  # pkg:gem/tapioca#lib/tapioca/dsl/pipeline.rb:167
   sig { params(error: ::String).void }
   def report_error(error); end
 end
@@ -5762,6 +5867,23 @@ end
 # pkg:gem/tapioca#lib/tapioca/helpers/rbi_helper.rb:97
 Tapioca::RBIHelper::TYPE_PARAMETER_MATCHER = T.let(T.unsafe(nil), Regexp)
 
+# pkg:gem/tapioca#lib/tapioca/rbs/rewriter.rb:9
+module Tapioca::RBS; end
+
+# Raises when the host calls `Bootsnap.setup` after tapioca's setup. Host's call
+# would overwrite tapioca's cache directory, so rewritten iseqs would end up in
+# the host's regular cache.
+#
+# pkg:gem/tapioca#lib/tapioca/rbs/rewriter.rb:15
+module Tapioca::RBS::BootsnapGuard
+  # pkg:gem/tapioca#lib/tapioca/rbs/rewriter.rb:19
+  sig { params(_kwargs: T.untyped).void }
+  def setup(**_kwargs); end
+end
+
+# pkg:gem/tapioca#lib/tapioca/rbs/rewriter.rb:10
+class Tapioca::RBS::HostBootsnapSetupError < ::StandardError; end
+
 # pkg:gem/tapioca#lib/tapioca/repo_index.rb:5
 class Tapioca::RepoIndex
   # pkg:gem/tapioca#lib/tapioca/repo_index.rb:21
@@ -5852,7 +5974,7 @@ end
 # This class is responsible for storing and looking up information related to generic types.
 #
 # The class stores 2 different kinds of data, in two separate lookup tables:
-#   1. a lookup of generic type instances by name: `@generic_instances`
+#   1. a lookup of generic type instances by constant and name: `@generic_instances`
 #   2. a lookup of type variable serializer by constant and type variable
 #      instance: `@type_variables`
 #
@@ -5870,25 +5992,26 @@ end
 # pkg:gem/tapioca#lib/tapioca/runtime/generic_type_registry.rb:23
 module Tapioca::Runtime::GenericTypeRegistry
   class << self
-    # pkg:gem/tapioca#lib/tapioca/runtime/generic_type_registry.rb:71
+    # pkg:gem/tapioca#lib/tapioca/runtime/generic_type_registry.rb:73
     def generic_type_instance?(instance); end
 
-    # pkg:gem/tapioca#lib/tapioca/runtime/generic_type_registry.rb:76
+    # pkg:gem/tapioca#lib/tapioca/runtime/generic_type_registry.rb:80
     def lookup_type_variables(constant); end
 
     # This method is responsible for building the name of the instantiated concrete type
     # and cloning the given constant so that we can return a type that is the same
     # as the current type but is a different instance and has a different name method.
     #
-    # We cache those cloned instances by their name in `@generic_instances`, so that
-    # we don't keep instantiating a new type every single time it is referenced.
+    # We cache those cloned instances by their original constant and their name in
+    # `@generic_instances`, so that we don't keep instantiating a new type every single
+    # time it is referenced.
     # For example, `[Foo[Integer], Foo[Integer], Foo[Integer], Foo[String]]` will only
     # result in 2 clones (1 for `Foo[Integer]` and another for `Foo[String]`) and
     # 2 hash lookups (for the other two `Foo[Integer]`s).
     #
     # This method returns the created or cached clone of the constant.
     #
-    # pkg:gem/tapioca#lib/tapioca/runtime/generic_type_registry.rb:56
+    # pkg:gem/tapioca#lib/tapioca/runtime/generic_type_registry.rb:57
     def register_type(constant, types); end
 
     # This method is called from intercepted calls to `type_member` and `type_template`.
@@ -5901,19 +6024,16 @@ module Tapioca::Runtime::GenericTypeRegistry
     # Finally, the original `type_variable` is returned from this method, so that the caller
     # can return it from the original methods as well.
     #
-    # pkg:gem/tapioca#lib/tapioca/runtime/generic_type_registry.rb:90
+    # pkg:gem/tapioca#lib/tapioca/runtime/generic_type_registry.rb:94
     def register_type_variable(constant, type_variable); end
 
     private
 
-    # pkg:gem/tapioca#lib/tapioca/runtime/generic_type_registry.rb:99
+    # pkg:gem/tapioca#lib/tapioca/runtime/generic_type_registry.rb:103
     def create_generic_type(constant, name); end
 
-    # pkg:gem/tapioca#lib/tapioca/runtime/generic_type_registry.rb:141
+    # pkg:gem/tapioca#lib/tapioca/runtime/generic_type_registry.rb:145
     def create_safe_subclass(constant); end
-
-    # pkg:gem/tapioca#lib/tapioca/runtime/generic_type_registry.rb:168
-    def lookup_or_initialize_type_variables(constant); end
   end
 end
 
@@ -6420,12 +6540,12 @@ Tapioca::TAPIOCA_CONFIG_FILE = T.let(T.unsafe(nil), String)
 # pkg:gem/tapioca#lib/tapioca.rb:15
 Tapioca::TAPIOCA_DIR = T.let(T.unsafe(nil), String)
 
-# pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:108
+# pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:88
 class Tapioca::TypeVariable < ::T::Types::TypeVariable
-  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:109
+  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:89
   def initialize(name, variance); end
 
-  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:114
+  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:94
   def name; end
 end
 
@@ -6435,36 +6555,36 @@ end
 # need to do any matching of constants to type variables to bind their names, Ruby will
 # do that automatically for us and we get the `name` method for free from `Module`.
 #
-# pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:122
+# pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:102
 class Tapioca::TypeVariableModule < ::Module
-  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:137
+  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:117
   def initialize(context, type, variance, bounds_proc); end
 
-  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:173
+  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:153
   def coerce_to_type_variable; end
 
-  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:153
+  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:133
   def fixed?; end
 
-  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:147
+  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:127
   def name; end
 
-  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:158
+  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:138
   def serialize; end
 
-  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:134
+  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:114
   def type; end
 
   private
 
-  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:180
+  # pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:160
   def bounds; end
 end
 
-# pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:131
+# pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:111
 Tapioca::TypeVariableModule::DEFAULT_BOUNDS_PROC = T.let(T.unsafe(nil), Proc)
 
-# pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:123
+# pkg:gem/tapioca#lib/tapioca/sorbet_ext/generic_name_patch.rb:103
 class Tapioca::TypeVariableModule::Type < ::T::Enum
   enums do
     HasAttachedClass = new


### PR DESCRIPTION
Bumps the `tapioca` ceiling to `<= 0.19.2` (same shape as #31).

The only breaking change in Tapioca 0.19.2 is Shopify/tapioca#2633, which simplifies constant filtering inside the DSL pipeline — it doesn't touch the compiler API Boba builds on.

Also regenerates the gem RBIs for `tapioca`, `spoom` and `rbi`, which moved with the update.

Ran locally (Ruby 4.0.6, everything else per CI):

- `bundle exec srb tc` — clean
- `bundle exec rubocop --fail-level error` — clean
- `bin/docs` — clean
- `bin/test` — 53 tests, 171 assertions, 0 failures
- `bin/tapioca gem --verify` — up-to-date
- `bin/tapioca check-shims` — no duplicates

Happy to switch the constraint to `~> 0.19` instead if you'd rather not re-cut a release for every Tapioca patch — say the word and I'll amend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)