### PR TITLE
MoneyRails: type the writer by what money-rails accepts, add the currency reader

### DIFF
--- a/lib/tapioca/dsl/compilers/money_rails.rb
+++ b/lib/tapioca/dsl/compilers/money_rails.rb
@@ -33,6 +33,9 @@ module Tapioca
       #  include MoneyRailsGeneratedMethods
       #
       #  module MoneyRailsGeneratedMethods
+      #    sig { returns(::Money::Currency) }
+      #    def currency_for_price; end
+      #
       #    sig { returns(::Money) }
       #    def price; end
       #
@@ -124,6 +127,10 @@ module Tapioca
                 "#{attribute_name}=",
                 parameters: [create_param("value", type: setter_type_name)],
                 return_type: setter_type_name,
+              )
+              instance_module.create_method(
+                "currency_for_#{attribute_name}",
+                return_type: column_type_option.untyped? ? "T.untyped" : "::Money::Currency",
               )
             end
 

--- a/lib/tapioca/dsl/compilers/money_rails.rb
+++ b/lib/tapioca/dsl/compilers/money_rails.rb
@@ -39,7 +39,7 @@ module Tapioca
       #    sig { returns(::Money) }
       #    def price; end
       #
-      #    sig { params(value: T.any(::Money, ::Numeric, ::String)).returns(T.any(::Money, ::Numeric, ::String)) }
+      #    sig { params(value: T.any(::Money, ::Numeric, ::String)).returns(::Money) }
       #    def price=(value); end
       #  end
       # end
@@ -126,11 +126,11 @@ module Tapioca
               instance_module.create_method(
                 "#{attribute_name}=",
                 parameters: [create_param("value", type: setter_type_name)],
-                return_type: setter_type_name,
+                return_type: type_name,
               )
               instance_module.create_method(
                 "currency_for_#{attribute_name}",
-                return_type: column_type_option.untyped? ? "T.untyped" : "::Money::Currency",
+                return_type: "::Money::Currency",
               )
             end
 

--- a/lib/tapioca/dsl/compilers/money_rails.rb
+++ b/lib/tapioca/dsl/compilers/money_rails.rb
@@ -36,13 +36,18 @@ module Tapioca
       #    sig { returns(::Money) }
       #    def price; end
       #
-      #    sig { params(value: ::Money).returns(::Money) }
+      #    sig { params(value: T.any(::Money, ::Numeric, ::String)).returns(T.any(::Money, ::Numeric, ::String)) }
       #    def price=(value); end
       #  end
       # end
       # ~~~
       class MoneyRails < Tapioca::Dsl::Compiler
         include RBIHelper
+
+        # `write_monetized` calls `value.to_money(...)` for anything that is not already a `Money`,
+        # so the writer accepts any object money-rails knows how to monetize, not only `Money`.
+        # https://github.com/RubyMoney/money-rails/blob/main/lib/money-rails/active_record/monetizable.rb
+        SetterValueType = "T.any(::Money, ::Numeric, ::String)"
 
         ConstantType = type_member do
           {
@@ -90,8 +95,10 @@ module Tapioca
             constant.monetized_attributes.each do |attribute_name, column_name|
               if column_type_option.untyped?
                 type_name = "T.untyped"
+                setter_type_name = "T.untyped"
               else
                 type_name = "::Money"
+                setter_type_name = SetterValueType
 
                 nilable_attribute = if constant < ::ActiveRecord::Base && column_type_option.persisted?
                   Boba::ActiveRecord::AttributeService.nilable_attribute?(
@@ -103,7 +110,10 @@ module Tapioca
                   true
                 end
 
-                type_name = as_nilable_type(type_name) if nilable_attribute
+                if nilable_attribute
+                  type_name = as_nilable_type(type_name)
+                  setter_type_name = as_nilable_type(setter_type_name)
+                end
               end
 
               # Model: monetize :amount_cents
@@ -112,8 +122,8 @@ module Tapioca
               instance_module.create_method(attribute_name, return_type: type_name)
               instance_module.create_method(
                 "#{attribute_name}=",
-                parameters: [create_param("value", type: type_name)],
-                return_type: type_name,
+                parameters: [create_param("value", type: setter_type_name)],
+                return_type: setter_type_name,
               )
             end
 

--- a/manual/compiler_moneyrails.md
+++ b/manual/compiler_moneyrails.md
@@ -26,7 +26,7 @@ class Product
    sig { returns(::Money) }
    def price; end
 
-   sig { params(value: ::Money).returns(::Money) }
+   sig { params(value: T.any(::Money, ::Numeric, ::String)).returns(T.any(::Money, ::Numeric, ::String)) }
    def price=(value); end
  end
 end

--- a/manual/compiler_moneyrails.md
+++ b/manual/compiler_moneyrails.md
@@ -29,7 +29,7 @@ class Product
    sig { returns(::Money) }
    def price; end
 
-   sig { params(value: T.any(::Money, ::Numeric, ::String)).returns(T.any(::Money, ::Numeric, ::String)) }
+   sig { params(value: T.any(::Money, ::Numeric, ::String)).returns(::Money) }
    def price=(value); end
  end
 end

--- a/manual/compiler_moneyrails.md
+++ b/manual/compiler_moneyrails.md
@@ -23,6 +23,9 @@ class Product
  include MoneyRailsGeneratedMethods
 
  module MoneyRailsGeneratedMethods
+   sig { returns(::Money::Currency) }
+   def currency_for_price; end
+
    sig { returns(::Money) }
    def price; end
 

--- a/spec/tapioca/dsl/compilers/money_rails_spec.rb
+++ b/spec/tapioca/dsl/compilers/money_rails_spec.rb
@@ -60,7 +60,7 @@ module Tapioca
                       sig { returns(T.nilable(::Money)) }
                       def price; end
 
-                      sig { params(value: T.nilable(::Money)).returns(T.nilable(::Money)) }
+                      sig { params(value: T.nilable(T.any(::Money, ::Numeric, ::String))).returns(T.nilable(T.any(::Money, ::Numeric, ::String))) }
                       def price=(value); end
                     end
                   end
@@ -91,7 +91,7 @@ module Tapioca
                     sig { returns(::Money) }
                     def price; end
 
-                    sig { params(value: ::Money).returns(::Money) }
+                    sig { params(value: T.any(::Money, ::Numeric, ::String)).returns(T.any(::Money, ::Numeric, ::String)) }
                     def price=(value); end
                   end
                 RBI
@@ -123,7 +123,7 @@ module Tapioca
                     sig { returns(::Money) }
                     def price; end
 
-                    sig { params(value: ::Money).returns(::Money) }
+                    sig { params(value: T.any(::Money, ::Numeric, ::String)).returns(T.any(::Money, ::Numeric, ::String)) }
                     def price=(value); end
                   end
                 RBI
@@ -161,7 +161,7 @@ module Tapioca
                       sig { returns(T.nilable(::Money)) }
                       def price; end
 
-                      sig { params(value: T.nilable(::Money)).returns(T.nilable(::Money)) }
+                      sig { params(value: T.nilable(T.any(::Money, ::Numeric, ::String))).returns(T.nilable(T.any(::Money, ::Numeric, ::String))) }
                       def price=(value); end
                     end
                   end
@@ -192,7 +192,7 @@ module Tapioca
                     sig { returns(T.nilable(::Money)) }
                     def price; end
 
-                    sig { params(value: T.nilable(::Money)).returns(T.nilable(::Money)) }
+                    sig { params(value: T.nilable(T.any(::Money, ::Numeric, ::String))).returns(T.nilable(T.any(::Money, ::Numeric, ::String))) }
                     def price=(value); end
                   end
                 RBI
@@ -224,7 +224,7 @@ module Tapioca
                     sig { returns(T.nilable(::Money)) }
                     def price; end
 
-                    sig { params(value: T.nilable(::Money)).returns(T.nilable(::Money)) }
+                    sig { params(value: T.nilable(T.any(::Money, ::Numeric, ::String))).returns(T.nilable(T.any(::Money, ::Numeric, ::String))) }
                     def price=(value); end
                   end
                 RBI

--- a/spec/tapioca/dsl/compilers/money_rails_spec.rb
+++ b/spec/tapioca/dsl/compilers/money_rails_spec.rb
@@ -57,6 +57,9 @@ module Tapioca
                     extend MoneyRails::ActiveRecord::Monetizable::ClassMethods
 
                     module MoneyRailsGeneratedMethods
+                      sig { returns(::Money::Currency) }
+                      def currency_for_price; end
+
                       sig { returns(T.nilable(::Money)) }
                       def price; end
 
@@ -88,6 +91,9 @@ module Tapioca
 
                 expected = indented(<<~RBI, 2)
                   module MoneyRailsGeneratedMethods
+                    sig { returns(::Money::Currency) }
+                    def currency_for_price; end
+
                     sig { returns(::Money) }
                     def price; end
 
@@ -120,6 +126,9 @@ module Tapioca
 
                 expected = indented(<<~RBI, 2)
                   module MoneyRailsGeneratedMethods
+                    sig { returns(::Money::Currency) }
+                    def currency_for_price; end
+
                     sig { returns(::Money) }
                     def price; end
 
@@ -158,6 +167,9 @@ module Tapioca
                     extend MoneyRails::ActiveRecord::Monetizable::ClassMethods
 
                     module MoneyRailsGeneratedMethods
+                      sig { returns(::Money::Currency) }
+                      def currency_for_price; end
+
                       sig { returns(T.nilable(::Money)) }
                       def price; end
 
@@ -189,6 +201,9 @@ module Tapioca
 
                 expected = indented(<<~RBI, 2)
                   module MoneyRailsGeneratedMethods
+                    sig { returns(::Money::Currency) }
+                    def currency_for_price; end
+
                     sig { returns(T.nilable(::Money)) }
                     def price; end
 
@@ -221,6 +236,9 @@ module Tapioca
 
                 expected = indented(<<~RBI, 2)
                   module MoneyRailsGeneratedMethods
+                    sig { returns(::Money::Currency) }
+                    def currency_for_price; end
+
                     sig { returns(T.nilable(::Money)) }
                     def price; end
 

--- a/spec/tapioca/dsl/compilers/money_rails_spec.rb
+++ b/spec/tapioca/dsl/compilers/money_rails_spec.rb
@@ -63,7 +63,7 @@ module Tapioca
                       sig { returns(T.nilable(::Money)) }
                       def price; end
 
-                      sig { params(value: T.nilable(T.any(::Money, ::Numeric, ::String))).returns(T.nilable(T.any(::Money, ::Numeric, ::String))) }
+                      sig { params(value: T.nilable(T.any(::Money, ::Numeric, ::String))).returns(T.nilable(::Money)) }
                       def price=(value); end
                     end
                   end
@@ -97,7 +97,7 @@ module Tapioca
                     sig { returns(::Money) }
                     def price; end
 
-                    sig { params(value: T.any(::Money, ::Numeric, ::String)).returns(T.any(::Money, ::Numeric, ::String)) }
+                    sig { params(value: T.any(::Money, ::Numeric, ::String)).returns(::Money) }
                     def price=(value); end
                   end
                 RBI
@@ -132,7 +132,7 @@ module Tapioca
                     sig { returns(::Money) }
                     def price; end
 
-                    sig { params(value: T.any(::Money, ::Numeric, ::String)).returns(T.any(::Money, ::Numeric, ::String)) }
+                    sig { params(value: T.any(::Money, ::Numeric, ::String)).returns(::Money) }
                     def price=(value); end
                   end
                 RBI
@@ -173,7 +173,7 @@ module Tapioca
                       sig { returns(T.nilable(::Money)) }
                       def price; end
 
-                      sig { params(value: T.nilable(T.any(::Money, ::Numeric, ::String))).returns(T.nilable(T.any(::Money, ::Numeric, ::String))) }
+                      sig { params(value: T.nilable(T.any(::Money, ::Numeric, ::String))).returns(T.nilable(::Money)) }
                       def price=(value); end
                     end
                   end
@@ -207,7 +207,7 @@ module Tapioca
                     sig { returns(T.nilable(::Money)) }
                     def price; end
 
-                    sig { params(value: T.nilable(T.any(::Money, ::Numeric, ::String))).returns(T.nilable(T.any(::Money, ::Numeric, ::String))) }
+                    sig { params(value: T.nilable(T.any(::Money, ::Numeric, ::String))).returns(T.nilable(::Money)) }
                     def price=(value); end
                   end
                 RBI
@@ -242,7 +242,7 @@ module Tapioca
                     sig { returns(T.nilable(::Money)) }
                     def price; end
 
-                    sig { params(value: T.nilable(T.any(::Money, ::Numeric, ::String))).returns(T.nilable(T.any(::Money, ::Numeric, ::String))) }
+                    sig { params(value: T.nilable(T.any(::Money, ::Numeric, ::String))).returns(T.nilable(::Money)) }
                     def price=(value); end
                   end
                 RBI


### PR DESCRIPTION
Two gaps we hit using the `MoneyRails` compiler on a Rails app with ~40 monetized attributes. Split into two commits so either can be dropped independently.

### 1. The writer accepts more than `Money`

[`write_monetized`](https://github.com/RubyMoney/money-rails/blob/main/lib/money-rails/active_record/monetizable.rb) only short-circuits when the value already is a `Money`; everything else goes through `value.to_money(currency_for_<name>)`. So `product.price = 1000`, `= BigDecimal("10.5")` or `= "10.50"` is ordinary usage, while the generated sig accepted `::Money` alone and made each of those an error under `srb tc`.

The writer is now `T.any(::Money, ::Numeric, ::String)`, nilable exactly when the reader is. The reader is untouched, and the `ActiveRecordColumnTypes: untyped` option still produces `T.untyped` for both.

### 2. `currency_for_<name>` was missing

`monetize :price_cents` also defines `currency_for_price` — money-rails calls it internally from both the reader and the writer, and apps read it to render or convert amounts. It's typed as non-nilable `::Money::Currency`: `currency_for` falls back through the instance currency column, the declared `:with_currency`, the class currency and finally `Money.default_currency`. `Money::Currency.find` can technically return `nil` for a currency name that doesn't resolve, but that's a misconfiguration rather than a state worth typing for — happy to make it nilable if you'd rather have the strict version.

### Notes

Specs, docs (`make docs`), `rubocop` and `srb tc` all pass locally.

We have a handful of other compilers written against this app (ransack, friendly_id, acts-as-taggable-on, paper_trail, neighbor, ruby_llm) that we'd like to upstream here as separate PRs — the README says compilers for commonly used gems are welcome, but say the word if you'd rather triage them through issues first.